### PR TITLE
Update lexical order midpoint formula

### DIFF
--- a/apps/backend/lib/lexicalOrder.ts
+++ b/apps/backend/lib/lexicalOrder.ts
@@ -66,6 +66,6 @@ export function generateOrder(
   }
   return (
     prev.slice(0, i + 1) +
-    String.fromCharCode(Math.floor(prevLastCode + CHAR_CODE_Z) / 2)
+    String.fromCharCode(Math.floor((prevLastCode + CHAR_CODE_Z) / 2))
   );
 }


### PR DESCRIPTION
## Summary
- fix mid character calculation in lexicalOrder utility

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a30f481c832a914f0e2d96f1688b