### PR TITLE
Add Maestro mobile E2E smoke tests

### DIFF
--- a/apps/mobile/.eas/workflows/e2e-test-android.yml
+++ b/apps/mobile/.eas/workflows/e2e-test-android.yml
@@ -1,0 +1,19 @@
+name: e2e-test-android
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build_android_for_e2e:
+    type: build
+    params:
+      platform: android
+      profile: e2e-test
+
+  maestro_test:
+    needs: [build_android_for_e2e]
+    type: maestro
+    params:
+      build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}
+      flow_path: [".maestro/smoke.yaml"]

--- a/apps/mobile/.eas/workflows/e2e-test-android.yml
+++ b/apps/mobile/.eas/workflows/e2e-test-android.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build_android_for_e2e:
+    environment: preview
     type: build
     params:
       platform: android
@@ -13,6 +14,9 @@ jobs:
 
   maestro_test:
     needs: [build_android_for_e2e]
+    environment: preview
+    env:
+      MAESTRO_APP_ID: ${{ env.BUNDLE_ID || 'com.actiko.app' }}
     type: maestro
     params:
       build_id: ${{ needs.build_android_for_e2e.outputs.build_id }}

--- a/apps/mobile/.eas/workflows/e2e-test-ios.yml
+++ b/apps/mobile/.eas/workflows/e2e-test-ios.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build_ios_for_e2e:
+    environment: preview
     type: build
     params:
       platform: ios
@@ -13,6 +14,9 @@ jobs:
 
   maestro_test:
     needs: [build_ios_for_e2e]
+    environment: preview
+    env:
+      MAESTRO_APP_ID: ${{ env.BUNDLE_ID || 'com.actiko.app' }}
     type: maestro
     params:
       build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}

--- a/apps/mobile/.eas/workflows/e2e-test-ios.yml
+++ b/apps/mobile/.eas/workflows/e2e-test-ios.yml
@@ -1,0 +1,19 @@
+name: e2e-test-ios
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build_ios_for_e2e:
+    type: build
+    params:
+      platform: ios
+      profile: e2e-test
+
+  maestro_test:
+    needs: [build_ios_for_e2e]
+    type: maestro
+    params:
+      build_id: ${{ needs.build_ios_for_e2e.outputs.build_id }}
+      flow_path: [".maestro/smoke.yaml"]

--- a/apps/mobile/.maestro/flows/create-task.yaml
+++ b/apps/mobile/.maestro/flows/create-task.yaml
@@ -1,0 +1,26 @@
+appId: com.actiko.app
+---
+- runFlow:
+    when:
+      visible:
+        id: tasks.emptyCreate
+    commands:
+      - tapOn:
+          id: tasks.emptyCreate
+- runFlow:
+    when:
+      visible:
+        id: tasks.add
+    commands:
+      - tapOn:
+          id: tasks.add
+- assertVisible:
+    id: tasks.create.dialog
+- tapOn:
+    id: tasks.create.titleInput
+- inputText: ${TASK_TITLE}
+- tapOn:
+    id: tasks.create.dialog
+- tapOn:
+    id: tasks.create.submit
+- assertVisible: ${TASK_TITLE}

--- a/apps/mobile/.maestro/flows/create-task.yaml
+++ b/apps/mobile/.maestro/flows/create-task.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: ${MAESTRO_APP_ID}
 ---
 - runFlow:
     when:

--- a/apps/mobile/.maestro/flows/create-task.yaml
+++ b/apps/mobile/.maestro/flows/create-task.yaml
@@ -1,4 +1,4 @@
-appId: com.actiko.app
+appId: ${APP_ID}
 ---
 - runFlow:
     when:

--- a/apps/mobile/.maestro/flows/login.yaml
+++ b/apps/mobile/.maestro/flows/login.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: ${MAESTRO_APP_ID}
 ---
 - assertVisible:
     id: login.screen

--- a/apps/mobile/.maestro/flows/login.yaml
+++ b/apps/mobile/.maestro/flows/login.yaml
@@ -1,0 +1,15 @@
+appId: com.actiko.app
+---
+- assertVisible:
+    id: login.screen
+- tapOn:
+    id: login.loginIdInput
+- inputText: ${LOGIN_ID}
+- tapOn:
+    id: login.passwordInput
+- inputText: ${PASSWORD}
+- hideKeyboard
+- tapOn:
+    id: login.submit
+- assertVisible:
+    id: tabs.tasks

--- a/apps/mobile/.maestro/flows/login.yaml
+++ b/apps/mobile/.maestro/flows/login.yaml
@@ -1,4 +1,4 @@
-appId: com.actiko.app
+appId: ${APP_ID}
 ---
 - assertVisible:
     id: login.screen

--- a/apps/mobile/.maestro/flows/open-tasks.yaml
+++ b/apps/mobile/.maestro/flows/open-tasks.yaml
@@ -1,0 +1,6 @@
+appId: com.actiko.app
+---
+- tapOn:
+    id: tabs.tasks
+- assertVisible:
+    id: tasks.page

--- a/apps/mobile/.maestro/flows/open-tasks.yaml
+++ b/apps/mobile/.maestro/flows/open-tasks.yaml
@@ -1,4 +1,4 @@
-appId: com.actiko.app
+appId: ${APP_ID}
 ---
 - tapOn:
     id: tabs.tasks

--- a/apps/mobile/.maestro/flows/open-tasks.yaml
+++ b/apps/mobile/.maestro/flows/open-tasks.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: ${MAESTRO_APP_ID}
 ---
 - tapOn:
     id: tabs.tasks

--- a/apps/mobile/.maestro/smoke.yaml
+++ b/apps/mobile/.maestro/smoke.yaml
@@ -1,6 +1,6 @@
-appId: ${APP_ID}
+appId: ${MAESTRO_APP_ID}
 env:
-  APP_ID: com.actiko.app
+  MAESTRO_APP_ID: com.actiko.app
   LOGIN_ID: e2e@example.com
   PASSWORD: password123
   TASK_TITLE: e2e-smoke-task

--- a/apps/mobile/.maestro/smoke.yaml
+++ b/apps/mobile/.maestro/smoke.yaml
@@ -1,0 +1,12 @@
+appId: ${APP_ID}
+env:
+  APP_ID: com.actiko.app
+  LOGIN_ID: e2e@example.com
+  PASSWORD: password123
+  TASK_TITLE: e2e-smoke-task
+---
+- launchApp:
+    clearState: true
+- runFlow: flows/login.yaml
+- runFlow: flows/open-tasks.yaml
+- runFlow: flows/create-task.yaml

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -83,7 +83,7 @@ eas build --platform android --profile e2e-local-android
 pnpm mobile:e2e:android:windows -- -ApkPath C:\path\to\actiko-e2e.apk
 ```
 
-この runner は local backend 起動、emulator 起動、`adb install`、Maestro 実行までまとめて行う。`maestro` が PATH に無い場合は `-MaestroPath C:\path\to\maestro.bat` を付ける。
+この runner は local backend 起動、emulator 起動、`adb install`、Maestro 実行までまとめて行う。`maestro` が PATH に無い場合は `-MaestroPath C:\path\to\maestro.bat` を付ける。既に backend を自分で起動している場合だけ `-SkipBackend` を使う。
 
 ### Mac で iOS smoke
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -52,6 +52,62 @@ cd apps/mobile
 npx expo start --web
 ```
 
+## Maestro E2E
+
+`apps/mobile/.maestro/smoke.yaml` に Android / iOS 共通の smoke flow を置いている。対象は `ログイン -> Tasks タブ移動 -> タスク作成`。
+
+### 前提
+
+- Maestro CLI をインストール済み
+- Android は emulator、iOS は Simulator を起動済み
+- Mac の local smoke は backend を別ターミナルで起動
+
+```bash
+pnpm mobile:e2e:server
+```
+
+### Windows で Android smoke
+
+Windows は `expo run:android` のネイティブ build が path length 制限に当たりやすいので、`e2e-local-android` で作った APK を emulator に入れて smoke を回す。
+
+1. Android APK を EAS で作る
+
+```bash
+cd apps/mobile
+eas build --platform android --profile e2e-local-android
+```
+
+2. smoke runner を実行する
+
+```bash
+pnpm mobile:e2e:android:windows -- -ApkPath C:\path\to\actiko-e2e.apk
+```
+
+この runner は local backend 起動、emulator 起動、`adb install`、Maestro 実行までまとめて行う。`maestro` が PATH に無い場合は `-MaestroPath C:\path\to\maestro.bat` を付ける。
+
+### Mac で iOS smoke
+
+1. Simulator へアプリを入れる
+
+```bash
+pnpm --filter actiko-mobile ios
+pnpm --filter actiko-mobile start:dev-client
+```
+
+2. Maestro を実行する
+
+```bash
+cd apps/mobile
+maestro test .maestro/smoke.yaml
+```
+
+### EAS Workflows
+
+- Android: `apps/mobile/.eas/workflows/e2e-test-android.yml`
+- iOS: `apps/mobile/.eas/workflows/e2e-test-ios.yml`
+
+`e2e-test` profile は emulator / simulator 用 artifact を作る。EAS 上で実行する場合、`EXPO_PUBLIC_API_URL` は EAS 環境変数として到達可能な backend を指す必要がある。
+
 ## 環境変数
 
 - ローカル: `.env` から読み込み（git管理外）

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -106,7 +106,7 @@ maestro test .maestro/smoke.yaml
 - Android: `apps/mobile/.eas/workflows/e2e-test-android.yml`
 - iOS: `apps/mobile/.eas/workflows/e2e-test-ios.yml`
 
-`e2e-test` profile は emulator / simulator 用 artifact を作る。EAS 上で実行する場合、`EXPO_PUBLIC_API_URL` は EAS 環境変数として到達可能な backend を指す必要がある。
+`e2e-test` profile は emulator / simulator 用 artifact を作り、EAS の `preview` environment を使う。`EXPO_PUBLIC_API_URL` はその environment に登録した到達可能な backend を指す必要がある。`BUNDLE_ID` を preview environment で上書きした場合、workflow 側の `MAESTRO_APP_ID` も同じ値を参照する。未指定時の既定値は `com.actiko.app`。
 
 ## 環境変数
 

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -61,7 +61,9 @@ const config: ExpoConfig = {
     },
   },
   owner: process.env.EAS_OWNER,
-  runtimeVersion: "1.0.0",
+  runtimeVersion: {
+    policy: "appVersion",
+  },
   ...(easProjectId && {
     updates: {
       url: `https://u.expo.dev/${easProjectId}`,

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig } from "expo/config";
 
-const bundleId = process.env.BUNDLE_ID;
+const bundleId = process.env.BUNDLE_ID ?? "com.actiko.app";
 const easProjectId = process.env.EAS_PROJECT_ID;
 const appleTeamId = process.env.APPLE_TEAM_ID;
 

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -50,6 +50,7 @@ const config: ExpoConfig = {
     "expo-updates",
     "expo-apple-authentication",
     "expo-image-picker",
+    "./plugins/with-android-cleartext.js",
     "./modules/timer-widget/app.plugin.js",
     "@bacons/apple-targets",
   ],
@@ -60,9 +61,7 @@ const config: ExpoConfig = {
     },
   },
   owner: process.env.EAS_OWNER,
-  runtimeVersion: {
-    policy: "appVersion",
-  },
+  runtimeVersion: "1.0.0",
   ...(easProjectId && {
     updates: {
       url: `https://u.expo.dev/${easProjectId}`,

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -11,7 +11,17 @@ import {
 } from "../../src/components/setting/tabPreferenceStore";
 import { useThemeContext } from "../../src/contexts/ThemeContext";
 import { useNavigationSync } from "../../src/hooks/useNavigationSync";
+import { mobileTestIds } from "../../src/testing/testIds";
 import { useAuthContext } from "../_layout";
+
+const TAB_TEST_IDS: Record<keyof typeof MOBILE_TAB_METADATA, string> = {
+  home: mobileTestIds.tabs.home,
+  daily: mobileTestIds.tabs.daily,
+  stats: mobileTestIds.tabs.stats,
+  goals: mobileTestIds.tabs.goals,
+  tasks: mobileTestIds.tabs.tasks,
+  notes: mobileTestIds.tabs.notes,
+};
 
 function CustomTabBar({ state, navigation }: BottomTabBarProps) {
   const insets = useSafeAreaInsets();
@@ -57,6 +67,7 @@ function CustomTabBar({ state, navigation }: BottomTabBarProps) {
               accessibilityRole="tab"
               accessibilityLabel={tab.label}
               accessibilityState={{ selected: isActive }}
+              testID={TAB_TEST_IDS[tab.key]}
               style={{
                 alignItems: "center",
                 gap: 2,

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -17,6 +17,7 @@
       "channel": "development"
     },
     "e2e-test": {
+      "environment": "preview",
       "withoutCredentials": true,
       "android": {
         "buildType": "apk"

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -16,6 +16,25 @@
       "distribution": "internal",
       "channel": "development"
     },
+    "e2e-test": {
+      "withoutCredentials": true,
+      "android": {
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": true
+      }
+    },
+    "e2e-local-android": {
+      "withoutCredentials": true,
+      "env": {
+        "ANDROID_USES_CLEARTEXT_TRAFFIC": "true",
+        "EXPO_PUBLIC_API_URL_ANDROID": "http://10.0.2.2:3536"
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
     "preview": {
       "distribution": "internal",
       "channel": "preview",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,7 @@
     "e2e:smoke:ios": "maestro test .maestro/smoke.yaml",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint ./src",
-    "test-once": "vitest run --config ../../vitest.config.ts apps/mobile"
+    "test-once": "pnpm --dir ../.. exec vitest run --config vitest.config.ts apps/mobile"
   },
   "dependencies": {
     "@bacons/apple-targets": "^4.0.6",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -5,9 +5,13 @@
   "scripts": {
     "dev": "expo start",
     "start": "expo start",
+    "start:dev-client": "expo start --dev-client",
     "web": "expo start --web",
     "android": "expo run:android",
     "ios": "expo run:ios",
+    "e2e:smoke": "maestro test .maestro/smoke.yaml",
+    "e2e:smoke:android": "maestro test .maestro/smoke.yaml",
+    "e2e:smoke:ios": "maestro test .maestro/smoke.yaml",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint ./src",
     "test-once": "vitest run --config ../../vitest.config.ts apps/mobile"

--- a/apps/mobile/plugins/with-android-cleartext.js
+++ b/apps/mobile/plugins/with-android-cleartext.js
@@ -1,0 +1,27 @@
+const {
+  createRunOncePlugin,
+  withAndroidManifest,
+} = require("expo/config-plugins");
+
+function withAndroidCleartext(config) {
+  return withAndroidManifest(config, (modConfig) => {
+    if (process.env.ANDROID_USES_CLEARTEXT_TRAFFIC !== "true") {
+      return modConfig;
+    }
+
+    const mainApp =
+      modConfig.modResults.manifest.application?.[0];
+    if (!mainApp) return modConfig;
+
+    if (!mainApp.$) mainApp.$ = {};
+    mainApp.$["android:usesCleartextTraffic"] = "true";
+
+    return modConfig;
+  });
+}
+
+module.exports = createRunOncePlugin(
+  withAndroidCleartext,
+  "with-android-cleartext",
+  "1.0.0",
+);

--- a/apps/mobile/src/components/common/FormButton.tsx
+++ b/apps/mobile/src/components/common/FormButton.tsx
@@ -8,6 +8,7 @@ type FormButtonProps = {
   onPress: () => void;
   disabled?: boolean;
   className?: string;
+  testID?: string;
 };
 
 const variantStyles: Record<
@@ -42,6 +43,7 @@ export function FormButton({
   onPress,
   disabled,
   className = "",
+  testID,
 }: FormButtonProps) {
   const style = variantStyles[variant];
   const buttonStyle = disabled ? style.buttonDisabled : style.button;
@@ -54,6 +56,7 @@ export function FormButton({
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ disabled: !!disabled }}
+      testID={testID}
     >
       <Text className={`font-medium text-sm ${style.text}`}>{label}</Text>
     </TouchableOpacity>

--- a/apps/mobile/src/components/common/ModalOverlay.tsx
+++ b/apps/mobile/src/components/common/ModalOverlay.tsx
@@ -29,6 +29,7 @@ type ModalOverlayProps = {
   title: string | React.ReactNode;
   children: React.ReactNode;
   footer?: React.ReactNode;
+  testID?: string;
 };
 
 export function ModalOverlay({
@@ -37,6 +38,7 @@ export function ModalOverlay({
   title,
   children,
   footer,
+  testID,
 }: ModalOverlayProps) {
   const { colors } = useThemeContext();
   const scrollViewRef = useRef<ScrollView>(null);
@@ -79,6 +81,7 @@ export function ModalOverlay({
           >
             <View
               className="bg-white dark:bg-gray-800 rounded-2xl w-full max-h-[85%]"
+              testID={testID}
               style={{
                 maxWidth: 448,
                 shadowColor: colors.shadowColor,

--- a/apps/mobile/src/components/root/LoginForm.tsx
+++ b/apps/mobile/src/components/root/LoginForm.tsx
@@ -1,6 +1,7 @@
 import * as AppleAuthentication from "expo-apple-authentication";
 import { Platform, Text, TouchableOpacity, View } from "react-native";
 
+import { mobileTestIds } from "../../testing/testIds";
 import { ActikoLogo } from "../common/ActikoLogo";
 import { FormInput } from "../common/FormInput";
 import { GoogleMark } from "../common/GoogleMark";
@@ -27,7 +28,10 @@ export function LoginForm() {
   } = useLoginForm();
 
   return (
-    <View className="flex-1 justify-center px-8 bg-white dark:bg-gray-800">
+    <View
+      className="flex-1 justify-center px-8 bg-white dark:bg-gray-800"
+      testID={mobileTestIds.login.screen}
+    >
       <View className="items-center mb-8">
         <ActikoLogo width={200} height={83} />
       </View>
@@ -46,6 +50,7 @@ export function LoginForm() {
         autoCapitalize="none"
         autoCorrect={false}
         accessibilityLabel={t("auth.loginId")}
+        testID={mobileTestIds.login.loginIdInput}
       />
 
       <FormInput
@@ -55,6 +60,7 @@ export function LoginForm() {
         onChangeText={setPassword}
         secureTextEntry
         accessibilityLabel={t("auth.password")}
+        testID={mobileTestIds.login.passwordInput}
       />
 
       <TouchableOpacity
@@ -63,6 +69,7 @@ export function LoginForm() {
         disabled={loading}
         accessibilityRole="button"
         accessibilityLabel={loading ? t("auth.loggingIn") : t("auth.login")}
+        testID={mobileTestIds.login.submitButton}
       >
         <Text className="text-white dark:text-gray-900 text-base font-semibold">
           {loading ? t("auth.loggingIn") : t("auth.login")}

--- a/apps/mobile/src/components/tasks/TaskCard.tsx
+++ b/apps/mobile/src/components/tasks/TaskCard.tsx
@@ -121,6 +121,7 @@ export function TaskCard({
               hitSlop={HIT_SLOP}
               accessibilityRole="button"
               accessibilityLabel={t("card.moveToToday")}
+              testID={testIds.moveToToday}
             >
               <CalendarCheck size={16} color="#9ca3af" />
             </TouchableOpacity>
@@ -132,6 +133,7 @@ export function TaskCard({
               hitSlop={HIT_SLOP}
               accessibilityRole="button"
               accessibilityLabel={t("card.archive")}
+              testID={testIds.archive}
             >
               <Archive size={16} color="#9ca3af" />
             </TouchableOpacity>
@@ -142,6 +144,7 @@ export function TaskCard({
             hitSlop={HIT_SLOP}
             accessibilityRole="button"
             accessibilityLabel={t("card.edit")}
+            testID={testIds.edit}
           >
             <Pencil size={16} color="#9ca3af" />
           </TouchableOpacity>
@@ -151,6 +154,7 @@ export function TaskCard({
             hitSlop={HIT_SLOP}
             accessibilityRole="button"
             accessibilityLabel={t("card.delete")}
+            testID={testIds.delete}
           >
             <Trash2 size={16} color="#9ca3af" />
           </TouchableOpacity>

--- a/apps/mobile/src/components/tasks/TaskCard.tsx
+++ b/apps/mobile/src/components/tasks/TaskCard.tsx
@@ -10,6 +10,7 @@ import {
 import { TouchableOpacity, View } from "react-native";
 import { Swipeable } from "react-native-gesture-handler";
 
+import { buildTaskCardTestIds } from "../../testing/testIds";
 import { TaskCardBody } from "./TaskCardBody";
 import { SwipeCompleteAction, SwipeDeleteAction } from "./TaskSwipeActions";
 import type { TaskItem } from "./types";
@@ -41,6 +42,7 @@ export function TaskCard({
   const { t } = useTranslation("task");
   const { linkedActivity, linkedKind, iconBlobMap, showMoveToToday } =
     useTaskCard(task, archived, onMoveToToday);
+  const testIds = buildTaskCardTestIds(task.title);
 
   return (
     <Swipeable
@@ -75,6 +77,7 @@ export function TaskCard({
               }
             : undefined
         }
+        testID={testIds.card}
       >
         {!archived && (
           <TouchableOpacity
@@ -84,6 +87,7 @@ export function TaskCard({
             accessibilityRole="checkbox"
             accessibilityState={{ checked: !!task.doneDate }}
             accessibilityLabel={task.title}
+            testID={testIds.toggle}
           >
             {task.doneDate ? (
               <CheckCircle2 size={22} color="#22c55e" />
@@ -95,6 +99,7 @@ export function TaskCard({
 
         <TaskCardBody
           title={task.title}
+          testID={testIds.title}
           completed={completed}
           doneDate={task.doneDate}
           startDate={task.startDate}

--- a/apps/mobile/src/components/tasks/TaskCard.tsx
+++ b/apps/mobile/src/components/tasks/TaskCard.tsx
@@ -42,7 +42,7 @@ export function TaskCard({
   const { t } = useTranslation("task");
   const { linkedActivity, linkedKind, iconBlobMap, showMoveToToday } =
     useTaskCard(task, archived, onMoveToToday);
-  const testIds = buildTaskCardTestIds(task.title);
+  const testIds = buildTaskCardTestIds(task.id);
 
   return (
     <Swipeable

--- a/apps/mobile/src/components/tasks/TaskCardBody.tsx
+++ b/apps/mobile/src/components/tasks/TaskCardBody.tsx
@@ -16,6 +16,7 @@ type IconBlob = { base64: string; mimeType: string };
 
 type TaskCardBodyProps = {
   title: string;
+  testID?: string;
   completed: boolean;
   doneDate?: string | null;
   startDate?: string | null;
@@ -31,6 +32,7 @@ type TaskCardBodyProps = {
 
 export function TaskCardBody({
   title,
+  testID,
   completed,
   doneDate,
   startDate,
@@ -46,7 +48,11 @@ export function TaskCardBody({
   const iconBlob = activityId ? iconBlobMap.get(activityId) : undefined;
 
   return (
-    <TouchableOpacity className="flex-1 min-w-0" onPress={onEdit}>
+    <TouchableOpacity
+      className="flex-1 min-w-0"
+      onPress={onEdit}
+      testID={testID}
+    >
       <Text
         className={`text-sm font-medium ${
           completed || doneDate

--- a/apps/mobile/src/components/tasks/TaskCreateDialog.tsx
+++ b/apps/mobile/src/components/tasks/TaskCreateDialog.tsx
@@ -6,6 +6,7 @@ import { useLiveQuery } from "../../db/useLiveQuery";
 import { useActivities } from "../../hooks/useActivities";
 import { useIconBlobMap } from "../../hooks/useIconBlobMap";
 import { activityRepository } from "../../repositories/activityRepository";
+import { mobileTestIds } from "../../testing/testIds";
 import { DatePickerField } from "../common/DatePickerField";
 import { FormButton } from "../common/FormButton";
 import { FormInput } from "../common/FormInput";
@@ -71,6 +72,7 @@ export function TaskCreateDialog({
       visible
       onClose={onClose}
       title={t("create.title")}
+      testID={mobileTestIds.tasks.createDialog}
       footer={
         <View className="flex-row gap-2">
           <FormButton
@@ -78,6 +80,7 @@ export function TaskCreateDialog({
             label={t("delete.cancel")}
             onPress={onClose}
             className="flex-1"
+            testID={mobileTestIds.tasks.createCancelButton}
           />
           <FormButton
             variant="primary"
@@ -85,6 +88,7 @@ export function TaskCreateDialog({
             onPress={handleCreate}
             disabled={isSubmitting || !title.trim()}
             className="flex-1"
+            testID={mobileTestIds.tasks.createSubmitButton}
           />
         </View>
       }
@@ -101,6 +105,7 @@ export function TaskCreateDialog({
             placeholder={t("create.placeholder.title")}
             autoFocus
             accessibilityLabel={t("create.label.title")}
+            testID={mobileTestIds.tasks.createTitleInput}
           />
         </View>
 
@@ -164,6 +169,7 @@ export function TaskCreateDialog({
             numberOfLines={3}
             style={{ textAlignVertical: "top" }}
             accessibilityLabel={t("create.label.memo")}
+            testID={mobileTestIds.tasks.createMemoInput}
           />
         </View>
       </View>

--- a/apps/mobile/src/components/tasks/TasksActiveTab.tsx
+++ b/apps/mobile/src/components/tasks/TasksActiveTab.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "@packages/i18n";
 import { Plus } from "lucide-react-native";
 import { Text, TouchableOpacity, View } from "react-native";
 
+import { mobileTestIds } from "../../testing/testIds";
 import { TaskGroup } from "./TaskGroup";
 import { TasksCompletedSection } from "./TasksCompletedSection";
 import { TasksFutureSection } from "./TasksFutureSection";
@@ -65,6 +66,7 @@ export function TasksActiveTab({
             className="px-4 py-2 bg-blue-600 rounded-lg"
             accessibilityRole="button"
             accessibilityLabel={t("page.firstTask")}
+            testID={mobileTestIds.tasks.emptyCreateButton}
           >
             <Text className="text-white text-sm">{t("page.firstTask")}</Text>
           </TouchableOpacity>
@@ -167,6 +169,7 @@ export function TasksActiveTab({
           className="py-5 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-800 flex-row items-center justify-center gap-2"
           accessibilityRole="button"
           accessibilityLabel={t("page.addNew")}
+          testID={mobileTestIds.tasks.addButton}
         >
           <Plus size={18} color="#9ca3af" />
           <Text className="text-sm text-gray-500 dark:text-gray-400">

--- a/apps/mobile/src/components/tasks/TasksPage.tsx
+++ b/apps/mobile/src/components/tasks/TasksPage.tsx
@@ -11,6 +11,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { syncEngine } from "../../sync/syncEngine";
+import { mobileTestIds } from "../../testing/testIds";
 import { DeleteConfirmDialog } from "./DeleteConfirmDialog";
 import { TaskCreateDialog } from "./TaskCreateDialog";
 import { TaskEditDialog } from "./TaskEditDialog";
@@ -60,7 +61,10 @@ export function TasksPage() {
   };
 
   return (
-    <View className="flex-1 bg-white dark:bg-gray-800">
+    <View
+      className="flex-1 bg-white dark:bg-gray-800"
+      testID={mobileTestIds.tasks.page}
+    >
       {/* Tabs */}
       <View
         className="flex-row items-center px-1 h-12 border-b border-gray-100 dark:border-gray-800"
@@ -74,6 +78,7 @@ export function TasksPage() {
           accessibilityRole="tab"
           accessibilityLabel={t("page.tab.active")}
           accessibilityState={{ selected: activeTab === "active" }}
+          testID={mobileTestIds.tasks.activeTab}
         >
           <Text
             className={`text-sm font-medium ${
@@ -93,6 +98,7 @@ export function TasksPage() {
           accessibilityRole="tab"
           accessibilityLabel={t("page.tab.archived")}
           accessibilityState={{ selected: activeTab === "archived" }}
+          testID={mobileTestIds.tasks.archivedTab}
         >
           <Text
             className={`text-sm font-medium ${

--- a/apps/mobile/src/testing/testIds.ts
+++ b/apps/mobile/src/testing/testIds.ts
@@ -37,8 +37,8 @@ function sanitizeTestIdSegment(value: string): string {
   return normalized || "item";
 }
 
-export function buildTaskCardTestIds(title: string) {
-  const suffix = sanitizeTestIdSegment(title);
+export function buildTaskCardTestIds(taskId: string) {
+  const suffix = sanitizeTestIdSegment(taskId);
   return {
     card: `tasks.card.${suffix}`,
     toggle: `tasks.toggle.${suffix}`,

--- a/apps/mobile/src/testing/testIds.ts
+++ b/apps/mobile/src/testing/testIds.ts
@@ -43,5 +43,9 @@ export function buildTaskCardTestIds(taskId: string) {
     card: `tasks.card.${suffix}`,
     toggle: `tasks.toggle.${suffix}`,
     title: `tasks.title.${suffix}`,
+    moveToToday: `tasks.moveToToday.${suffix}`,
+    archive: `tasks.archive.${suffix}`,
+    edit: `tasks.edit.${suffix}`,
+    delete: `tasks.delete.${suffix}`,
   };
 }

--- a/apps/mobile/src/testing/testIds.ts
+++ b/apps/mobile/src/testing/testIds.ts
@@ -1,0 +1,47 @@
+export const mobileTestIds = {
+  login: {
+    screen: "login.screen",
+    loginIdInput: "login.loginIdInput",
+    passwordInput: "login.passwordInput",
+    submitButton: "login.submit",
+  },
+  tabs: {
+    home: "tabs.home",
+    daily: "tabs.daily",
+    stats: "tabs.stats",
+    goals: "tabs.goals",
+    tasks: "tabs.tasks",
+    notes: "tabs.notes",
+  },
+  tasks: {
+    page: "tasks.page",
+    activeTab: "tasks.tab.active",
+    archivedTab: "tasks.tab.archived",
+    emptyCreateButton: "tasks.emptyCreate",
+    addButton: "tasks.add",
+    createDialog: "tasks.create.dialog",
+    createTitleInput: "tasks.create.titleInput",
+    createMemoInput: "tasks.create.memoInput",
+    createCancelButton: "tasks.create.cancel",
+    createSubmitButton: "tasks.create.submit",
+  },
+} as const;
+
+function sanitizeTestIdSegment(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized || "item";
+}
+
+export function buildTaskCardTestIds(title: string) {
+  const suffix = sanitizeTestIdSegment(title);
+  return {
+    card: `tasks.card.${suffix}`,
+    toggle: `tasks.toggle.${suffix}`,
+    title: `tasks.title.${suffix}`,
+  };
+}

--- a/apps/mobile/src/utils/apiClient.ts
+++ b/apps/mobile/src/utils/apiClient.ts
@@ -7,23 +7,25 @@ import Constants from "expo-constants";
 import * as SecureStore from "expo-secure-store";
 import { Platform } from "react-native";
 
+import { resolveNativeApiUrl } from "./apiUrlResolver";
+
 const REQUEST_TIMEOUT_MS = 15_000;
 
 function resolveApiUrl(): string {
-  if (process.env.EXPO_PUBLIC_API_URL) return process.env.EXPO_PUBLIC_API_URL;
-  // Expo Go / dev client: use the same host IP that Metro bundler uses
-  if (__DEV__) {
-    const debuggerHost = Constants.expoGoConfig?.debuggerHost;
-    if (debuggerHost) {
-      const host = debuggerHost.split(":")[0];
-      return `http://${host}:3456`;
-    }
-    return "http://localhost:3456";
-  }
-  // 本番ビルドで EXPO_PUBLIC_API_URL が未設定 → 起動時にクラッシュさせて気付けるようにする
-  throw new Error(
-    "EXPO_PUBLIC_API_URL is not set. Production builds require this environment variable.",
-  );
+  const configuredUrl =
+    (Platform.OS === "android"
+      ? process.env.EXPO_PUBLIC_API_URL_ANDROID
+      : Platform.OS === "ios"
+        ? process.env.EXPO_PUBLIC_API_URL_IOS
+        : process.env.EXPO_PUBLIC_API_URL_WEB) ??
+    process.env.EXPO_PUBLIC_API_URL;
+
+  return resolveNativeApiUrl({
+    configuredUrl,
+    debuggerHost: Constants.expoGoConfig?.debuggerHost,
+    isDev: __DEV__,
+    platform: Platform.OS,
+  });
 }
 
 const API_URL = resolveApiUrl();

--- a/apps/mobile/src/utils/apiUrlResolver.test.ts
+++ b/apps/mobile/src/utils/apiUrlResolver.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveNativeApiUrl } from "./apiUrlResolver";
+
+describe("resolveNativeApiUrl", () => {
+  it("rewrites localhost configured URL for Android dev", () => {
+    expect(
+      resolveNativeApiUrl({
+        configuredUrl: "http://localhost:3536",
+        debuggerHost: "192.168.0.10:8081",
+        isDev: true,
+        platform: "android",
+      }),
+    ).toBe("http://192.168.0.10:3536");
+  });
+
+  it("falls back to Android emulator host in dev", () => {
+    expect(
+      resolveNativeApiUrl({
+        isDev: true,
+        platform: "android",
+      }),
+    ).toBe("http://10.0.2.2:3456");
+  });
+
+  it("keeps localhost for iOS dev", () => {
+    expect(
+      resolveNativeApiUrl({
+        configuredUrl: "http://localhost:3536",
+        isDev: true,
+        platform: "ios",
+      }),
+    ).toBe("http://localhost:3536");
+  });
+
+  it("uses debugger host when no URL is configured", () => {
+    expect(
+      resolveNativeApiUrl({
+        debuggerHost: "10.1.2.3:8081",
+        isDev: true,
+        platform: "ios",
+      }),
+    ).toBe("http://10.1.2.3:3456");
+  });
+
+  it("throws when production URL is missing", () => {
+    expect(() =>
+      resolveNativeApiUrl({
+        isDev: false,
+        platform: "ios",
+      }),
+    ).toThrow(
+      "EXPO_PUBLIC_API_URL is not set. Production builds require this environment variable.",
+    );
+  });
+});

--- a/apps/mobile/src/utils/apiUrlResolver.test.ts
+++ b/apps/mobile/src/utils/apiUrlResolver.test.ts
@@ -23,6 +23,27 @@ describe("resolveNativeApiUrl", () => {
     ).toBe("http://10.0.2.2:3456");
   });
 
+  it("ignores localhost debugger host on Android dev", () => {
+    expect(
+      resolveNativeApiUrl({
+        configuredUrl: "http://localhost:3536",
+        debuggerHost: "localhost:8081",
+        isDev: true,
+        platform: "android",
+      }),
+    ).toBe("http://10.0.2.2:3536");
+  });
+
+  it("falls back to Android emulator host when debugger host is localhost", () => {
+    expect(
+      resolveNativeApiUrl({
+        debuggerHost: "localhost:8081",
+        isDev: true,
+        platform: "android",
+      }),
+    ).toBe("http://10.0.2.2:3456");
+  });
+
   it("keeps localhost for iOS dev", () => {
     expect(
       resolveNativeApiUrl({

--- a/apps/mobile/src/utils/apiUrlResolver.ts
+++ b/apps/mobile/src/utils/apiUrlResolver.ts
@@ -1,0 +1,62 @@
+export const DEFAULT_DEV_API_PORT = 3456;
+const ANDROID_EMULATOR_HOST = "10.0.2.2";
+
+type ResolveApiUrlOptions = {
+  configuredUrl?: string;
+  debuggerHost?: string | null;
+  isDev: boolean;
+  platform: "android" | "ios" | "web" | "windows" | "macos";
+};
+
+function getDebuggerHostName(debuggerHost?: string | null): string | null {
+  if (!debuggerHost) return null;
+  return debuggerHost.split(":")[0] || null;
+}
+
+function rewriteConfiguredUrlForAndroidDev(
+  configuredUrl: string,
+  debuggerHost?: string | null,
+): string {
+  const parsed = new URL(configuredUrl);
+  if (
+    parsed.hostname !== "localhost" &&
+    parsed.hostname !== "127.0.0.1" &&
+    parsed.hostname !== "::1"
+  ) {
+    return configuredUrl;
+  }
+
+  parsed.hostname = getDebuggerHostName(debuggerHost) ?? ANDROID_EMULATOR_HOST;
+  return parsed.toString().replace(/\/$/, "");
+}
+
+export function resolveNativeApiUrl({
+  configuredUrl,
+  debuggerHost,
+  isDev,
+  platform,
+}: ResolveApiUrlOptions): string {
+  if (configuredUrl) {
+    if (isDev && platform === "android") {
+      return rewriteConfiguredUrlForAndroidDev(configuredUrl, debuggerHost);
+    }
+    return configuredUrl;
+  }
+
+  if (!isDev) {
+    throw new Error(
+      "EXPO_PUBLIC_API_URL is not set. Production builds require this environment variable.",
+    );
+  }
+
+  const host = getDebuggerHostName(debuggerHost);
+  if (host) {
+    return `http://${host}:${DEFAULT_DEV_API_PORT}`;
+  }
+
+  if (platform === "android") {
+    return `http://${ANDROID_EMULATOR_HOST}:${DEFAULT_DEV_API_PORT}`;
+  }
+
+  return `http://localhost:${DEFAULT_DEV_API_PORT}`;
+}

--- a/apps/mobile/src/utils/apiUrlResolver.ts
+++ b/apps/mobile/src/utils/apiUrlResolver.ts
@@ -14,20 +14,28 @@ function getDebuggerHostName(debuggerHost?: string | null): string | null {
   return debuggerHost.split(":")[0] || null;
 }
 
+function isLoopbackHost(host?: string | null): boolean {
+  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+}
+
+function getAndroidDevHost(debuggerHost?: string | null): string {
+  const host = getDebuggerHostName(debuggerHost);
+  if (!host || isLoopbackHost(host)) {
+    return ANDROID_EMULATOR_HOST;
+  }
+  return host;
+}
+
 function rewriteConfiguredUrlForAndroidDev(
   configuredUrl: string,
   debuggerHost?: string | null,
 ): string {
   const parsed = new URL(configuredUrl);
-  if (
-    parsed.hostname !== "localhost" &&
-    parsed.hostname !== "127.0.0.1" &&
-    parsed.hostname !== "::1"
-  ) {
+  if (!isLoopbackHost(parsed.hostname)) {
     return configuredUrl;
   }
 
-  parsed.hostname = getDebuggerHostName(debuggerHost) ?? ANDROID_EMULATOR_HOST;
+  parsed.hostname = getAndroidDevHost(debuggerHost);
   return parsed.toString().replace(/\/$/, "");
 }
 
@@ -51,7 +59,7 @@ export function resolveNativeApiUrl({
   }
 
   const host = getDebuggerHostName(debuggerHost);
-  if (host) {
+  if (host && (platform !== "android" || !isLoopbackHost(host))) {
     return `http://${host}:${DEFAULT_DEV_API_PORT}`;
   }
 

--- a/apps/mobile/src/utils/apiUrlResolver.ts
+++ b/apps/mobile/src/utils/apiUrlResolver.ts
@@ -1,4 +1,5 @@
-export const DEFAULT_DEV_API_PORT = 3456;
+import { DEFAULT_DEV_API_PORT } from "@packages/platform";
+
 const ANDROID_EMULATOR_HOST = "10.0.2.2";
 
 type ResolveApiUrlOptions = {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "db-migrate": "drizzle-kit migrate --config=infra/drizzle/drizzle.config.ts",
     "db-seed": "tsx scripts/seed-dev-data.ts",
     "db-clean": "tsx scripts/clean-db.ts",
+    "mobile:e2e:android:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/mobile-e2e-android-windows.ps1",
+    "mobile:e2e:server": "tsx scripts/mobile-e2e-server.ts",
     "gen-be": "node scripts/gen-be.js",
     "generate:api-reference": "tsx scripts/generate-api-reference.ts && biome check apps/frontend/src/components/api-reference/apiReferenceData.generated.ts --write --unsafe",
     "mobile": "pnpm --filter actiko-mobile"

--- a/packages/platform/apiPorts.ts
+++ b/packages/platform/apiPorts.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_DEV_API_PORT = 3456;

--- a/packages/platform/index.ts
+++ b/packages/platform/index.ts
@@ -1,2 +1,3 @@
 export * from "./adapters";
 export * from "./auth/tokenStorage";
+export * from "./apiPorts";

--- a/scripts/mobile-e2e-android-windows.ps1
+++ b/scripts/mobile-e2e-android-windows.ps1
@@ -272,7 +272,7 @@ try {
 
   Push-Location (Join-Path $repoRoot "apps/mobile")
   try {
-    & $maestroExecutable test ".maestro/smoke.yaml" -e "APP_ID=$AppId"
+    & $maestroExecutable test ".maestro/smoke.yaml" -e "MAESTRO_APP_ID=$AppId"
     if ($LASTEXITCODE -ne 0) {
       throw "Maestro smoke test failed."
     }

--- a/scripts/mobile-e2e-android-windows.ps1
+++ b/scripts/mobile-e2e-android-windows.ps1
@@ -272,7 +272,7 @@ try {
 
   Push-Location (Join-Path $repoRoot "apps/mobile")
   try {
-    & $maestroExecutable test ".maestro/smoke.yaml"
+    & $maestroExecutable test ".maestro/smoke.yaml" -e "APP_ID=$AppId"
     if ($LASTEXITCODE -ne 0) {
       throw "Maestro smoke test failed."
     }

--- a/scripts/mobile-e2e-android-windows.ps1
+++ b/scripts/mobile-e2e-android-windows.ps1
@@ -31,29 +31,130 @@ function Resolve-CommandPath {
   return $command.Source
 }
 
+function Get-ConnectedDeviceSerials {
+  $lines = & $script:AdbExecutable devices
+
+  return $lines |
+    Select-Object -Skip 1 |
+    Where-Object { $_ -match "`tdevice$" } |
+    ForEach-Object { ($_ -split "`t")[0].Trim() } |
+    Where-Object { $_ }
+}
+
+function Get-EmulatorSerials {
+  return Get-ConnectedDeviceSerials | Where-Object { $_ -like "emulator-*" }
+}
+
+function Get-EmulatorAvdName {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Serial
+  )
+
+  try {
+    $lines = & $script:AdbExecutable -s $Serial emu avd name 2>$null
+    foreach ($line in $lines) {
+      $trimmed = $line.Trim()
+      if ($trimmed -and $trimmed -ne "OK") {
+        return $trimmed
+      }
+    }
+  } catch {
+  }
+
+  return $null
+}
+
 function Wait-ForAndroidDevice {
   param(
+    [Parameter(Mandatory = $true)]
+    [string]$Serial,
     [int]$TimeoutSeconds = 240
   )
 
   $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
   do {
     Start-Sleep -Seconds 5
-    $devices = & $script:AdbExecutable devices
+    $devices = Get-ConnectedDeviceSerials
     $bootCompleted = ""
 
     try {
-      $bootCompleted = (& $script:AdbExecutable shell getprop sys.boot_completed 2>$null).Trim()
+      $bootCompleted = (& $script:AdbExecutable -s $Serial shell getprop sys.boot_completed 2>$null).Trim()
     } catch {
       $bootCompleted = ""
     }
 
-    if ($devices -match "`tdevice" -and $bootCompleted -eq "1") {
+    if (($devices -contains $Serial) -and $bootCompleted -eq "1") {
       return
     }
   } while ((Get-Date) -lt $deadline)
 
-  throw "Android emulator did not become ready within $TimeoutSeconds seconds."
+  throw "Android device $Serial did not become ready within $TimeoutSeconds seconds."
+}
+
+function Find-RunningEmulatorSerial {
+  param(
+    [string]$AvdName
+  )
+
+  $emulatorSerials = Get-EmulatorSerials
+  if (-not $emulatorSerials) {
+    return $null
+  }
+
+  if ($AvdName) {
+    foreach ($serial in $emulatorSerials) {
+      if ((Get-EmulatorAvdName -Serial $serial) -eq $AvdName) {
+        return $serial
+      }
+    }
+    return $null
+  }
+
+  if ($emulatorSerials.Count -eq 1) {
+    return $emulatorSerials[0]
+  }
+
+  throw "Multiple Android emulators are connected. Pass -AvdName to select one."
+}
+
+function Start-AndroidEmulator {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ResolvedAvdName,
+    [string[]]$ExistingEmulatorSerials
+  )
+
+  $emulatorOutLog = Join-Path $logDir "mobile-e2e-emulator.out.log"
+  $emulatorErrLog = Join-Path $logDir "mobile-e2e-emulator.err.log"
+
+  Start-Process -FilePath $script:EmulatorExecutable -ArgumentList "-avd", $ResolvedAvdName, "-no-snapshot-load" -RedirectStandardOutput $emulatorOutLog -RedirectStandardError $emulatorErrLog | Out-Null
+
+  $deadline = (Get-Date).AddSeconds(240)
+  do {
+    Start-Sleep -Seconds 5
+    $currentEmulatorSerials = Get-EmulatorSerials
+    foreach ($serial in $currentEmulatorSerials) {
+      $matchesAvd =
+        -not $ResolvedAvdName -or
+        (Get-EmulatorAvdName -Serial $serial) -eq $ResolvedAvdName
+      if (-not $matchesAvd) {
+        continue
+      }
+
+      if (($ExistingEmulatorSerials -notcontains $serial) -or $currentEmulatorSerials.Count -eq 1) {
+        try {
+          $bootCompleted = (& $script:AdbExecutable -s $serial shell getprop sys.boot_completed 2>$null).Trim()
+          if ($bootCompleted -eq "1") {
+            return $serial
+          }
+        } catch {
+        }
+      }
+    }
+  } while ((Get-Date) -lt $deadline)
+
+  throw "Android emulator $ResolvedAvdName did not become ready within 240 seconds."
 }
 
 function Wait-ForBackend {
@@ -137,18 +238,17 @@ $maestroExecutable = Resolve-MaestroExecutable -ExplicitPath $MaestroPath
 
 $backendProcess = $null
 $startedEmulator = $false
+$targetDeviceSerial = $null
 
 try {
-  $devices = & $script:AdbExecutable devices
-  if ($devices -notmatch "`tdevice") {
+  $targetDeviceSerial = Find-RunningEmulatorSerial -AvdName $AvdName
+  if (-not $targetDeviceSerial) {
     $resolvedAvdName = Resolve-AvdName -ExplicitName $AvdName
-    $emulatorOutLog = Join-Path $logDir "mobile-e2e-emulator.out.log"
-    $emulatorErrLog = Join-Path $logDir "mobile-e2e-emulator.err.log"
-
-    Start-Process -FilePath $script:EmulatorExecutable -ArgumentList "-avd", $resolvedAvdName, "-no-snapshot-load" -RedirectStandardOutput $emulatorOutLog -RedirectStandardError $emulatorErrLog | Out-Null
+    $existingEmulatorSerials = @(Get-EmulatorSerials)
+    $targetDeviceSerial = Start-AndroidEmulator -ResolvedAvdName $resolvedAvdName -ExistingEmulatorSerials $existingEmulatorSerials
     $startedEmulator = $true
   }
-  Wait-ForAndroidDevice
+  Wait-ForAndroidDevice -Serial $targetDeviceSerial
 
   if (-not $SkipBackend) {
     if (-not (Test-ListeningPort -Port $ApiPort)) {
@@ -162,12 +262,12 @@ try {
     Wait-ForBackend -Port $ApiPort
   }
 
-  & $script:AdbExecutable install -r $resolvedApkPath
+  & $script:AdbExecutable -s $targetDeviceSerial install -r $resolvedApkPath
   if ($LASTEXITCODE -ne 0) {
     throw "adb install failed."
   }
 
-  & $script:AdbExecutable shell monkey -p $AppId -c android.intent.category.LAUNCHER 1 | Out-Null
+  & $script:AdbExecutable -s $targetDeviceSerial shell monkey -p $AppId -c android.intent.category.LAUNCHER 1 | Out-Null
   Start-Sleep -Seconds 5
 
   Push-Location (Join-Path $repoRoot "apps/mobile")
@@ -184,9 +284,9 @@ try {
     Stop-Process -Id $backendProcess.Id -Force
   }
 
-  if ($startedEmulator) {
+  if ($startedEmulator -and $targetDeviceSerial) {
     try {
-      & $script:AdbExecutable emu kill | Out-Null
+      & $script:AdbExecutable -s $targetDeviceSerial emu kill | Out-Null
     } catch {
     }
   }

--- a/scripts/mobile-e2e-android-windows.ps1
+++ b/scripts/mobile-e2e-android-windows.ps1
@@ -251,13 +251,15 @@ try {
   Wait-ForAndroidDevice -Serial $targetDeviceSerial
 
   if (-not $SkipBackend) {
-    if (-not (Test-ListeningPort -Port $ApiPort)) {
-      $backendOutLog = Join-Path $logDir "mobile-e2e-server.out.log"
-      $backendErrLog = Join-Path $logDir "mobile-e2e-server.err.log"
-      $backendCommand = "Set-Location '$repoRoot'; `$env:API_PORT='$ApiPort'; pnpm mobile:e2e:server"
-
-      $backendProcess = Start-Process -FilePath "powershell" -ArgumentList "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", $backendCommand -RedirectStandardOutput $backendOutLog -RedirectStandardError $backendErrLog -PassThru
+    if (Test-ListeningPort -Port $ApiPort) {
+      throw "Port $ApiPort is already in use. Stop the existing process or pass -SkipBackend to reuse a running backend intentionally."
     }
+
+    $backendOutLog = Join-Path $logDir "mobile-e2e-server.out.log"
+    $backendErrLog = Join-Path $logDir "mobile-e2e-server.err.log"
+    $backendCommand = "Set-Location '$repoRoot'; `$env:API_PORT='$ApiPort'; pnpm mobile:e2e:server"
+
+    $backendProcess = Start-Process -FilePath "powershell" -ArgumentList "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", $backendCommand -RedirectStandardOutput $backendOutLog -RedirectStandardError $backendErrLog -PassThru
 
     Wait-ForBackend -Port $ApiPort
   }

--- a/scripts/mobile-e2e-android-windows.ps1
+++ b/scripts/mobile-e2e-android-windows.ps1
@@ -1,0 +1,193 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ApkPath,
+  [string]$AvdName,
+  [string]$MaestroPath,
+  [int]$ApiPort = 3536,
+  [string]$AppId = "com.actiko.app",
+  [switch]$SkipBackend
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$script:AdbExecutable = ""
+$script:EmulatorExecutable = ""
+
+function Get-RepoRoot {
+  return [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+}
+
+function Resolve-CommandPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$CommandName
+  )
+
+  $command = Get-Command $CommandName -ErrorAction SilentlyContinue
+  if ($null -eq $command) {
+    throw "Command not found: $CommandName"
+  }
+
+  return $command.Source
+}
+
+function Wait-ForAndroidDevice {
+  param(
+    [int]$TimeoutSeconds = 240
+  )
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  do {
+    Start-Sleep -Seconds 5
+    $devices = & $script:AdbExecutable devices
+    $bootCompleted = ""
+
+    try {
+      $bootCompleted = (& $script:AdbExecutable shell getprop sys.boot_completed 2>$null).Trim()
+    } catch {
+      $bootCompleted = ""
+    }
+
+    if ($devices -match "`tdevice" -and $bootCompleted -eq "1") {
+      return
+    }
+  } while ((Get-Date) -lt $deadline)
+
+  throw "Android emulator did not become ready within $TimeoutSeconds seconds."
+}
+
+function Wait-ForBackend {
+  param(
+    [int]$Port,
+    [int]$TimeoutSeconds = 120
+  )
+
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $uri = "http://localhost:$Port/auth/login"
+  $body = '{"login_id":"e2e@example.com","password":"password123"}'
+
+  do {
+    Start-Sleep -Seconds 2
+    try {
+      $response = Invoke-RestMethod -Method Post -Uri $uri -ContentType "application/json" -Body $body -TimeoutSec 3
+      if ($response.token) {
+        return
+      }
+    } catch {
+    }
+  } while ((Get-Date) -lt $deadline)
+
+  throw "Mobile E2E backend did not become ready on port $Port."
+}
+
+function Resolve-MaestroExecutable {
+  param(
+    [string]$ExplicitPath
+  )
+
+  if ($ExplicitPath) {
+    $resolved = Resolve-Path $ExplicitPath -ErrorAction Stop
+    return $resolved.Path
+  }
+
+  $command = Get-Command maestro -ErrorAction SilentlyContinue
+  if ($null -ne $command) {
+    return $command.Source
+  }
+
+  throw "Maestro CLI was not found. Install Maestro or pass -MaestroPath."
+}
+
+function Resolve-AvdName {
+  param(
+    [string]$ExplicitName
+  )
+
+  if ($ExplicitName) {
+    return $ExplicitName
+  }
+
+  $avds = (& $script:EmulatorExecutable -list-avds) | Where-Object { $_.Trim().Length -gt 0 }
+  if ($avds.Count -eq 1) {
+    return $avds[0].Trim()
+  }
+
+  throw "Could not infer a single AVD. Pass -AvdName."
+}
+
+function Test-ListeningPort {
+  param(
+    [int]$Port
+  )
+
+  $connections = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+  return $null -ne $connections
+}
+
+$repoRoot = Get-RepoRoot
+$logDir = Join-Path $repoRoot "tmp/process-logs"
+if (-not (Test-Path $logDir)) {
+  New-Item -ItemType Directory -Path $logDir | Out-Null
+}
+
+$resolvedApkPath = (Resolve-Path $ApkPath -ErrorAction Stop).Path
+$script:AdbExecutable = Resolve-CommandPath -CommandName "adb"
+$script:EmulatorExecutable = Resolve-CommandPath -CommandName "emulator"
+$maestroExecutable = Resolve-MaestroExecutable -ExplicitPath $MaestroPath
+
+$backendProcess = $null
+$startedEmulator = $false
+
+try {
+  $devices = & $script:AdbExecutable devices
+  if ($devices -notmatch "`tdevice") {
+    $resolvedAvdName = Resolve-AvdName -ExplicitName $AvdName
+    $emulatorOutLog = Join-Path $logDir "mobile-e2e-emulator.out.log"
+    $emulatorErrLog = Join-Path $logDir "mobile-e2e-emulator.err.log"
+
+    Start-Process -FilePath $script:EmulatorExecutable -ArgumentList "-avd", $resolvedAvdName, "-no-snapshot-load" -RedirectStandardOutput $emulatorOutLog -RedirectStandardError $emulatorErrLog | Out-Null
+    $startedEmulator = $true
+  }
+  Wait-ForAndroidDevice
+
+  if (-not $SkipBackend) {
+    if (-not (Test-ListeningPort -Port $ApiPort)) {
+      $backendOutLog = Join-Path $logDir "mobile-e2e-server.out.log"
+      $backendErrLog = Join-Path $logDir "mobile-e2e-server.err.log"
+      $backendCommand = "Set-Location '$repoRoot'; `$env:API_PORT='$ApiPort'; pnpm mobile:e2e:server"
+
+      $backendProcess = Start-Process -FilePath "powershell" -ArgumentList "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", $backendCommand -RedirectStandardOutput $backendOutLog -RedirectStandardError $backendErrLog -PassThru
+    }
+
+    Wait-ForBackend -Port $ApiPort
+  }
+
+  & $script:AdbExecutable install -r $resolvedApkPath
+  if ($LASTEXITCODE -ne 0) {
+    throw "adb install failed."
+  }
+
+  & $script:AdbExecutable shell monkey -p $AppId -c android.intent.category.LAUNCHER 1 | Out-Null
+  Start-Sleep -Seconds 5
+
+  Push-Location (Join-Path $repoRoot "apps/mobile")
+  try {
+    & $maestroExecutable test ".maestro/smoke.yaml"
+    if ($LASTEXITCODE -ne 0) {
+      throw "Maestro smoke test failed."
+    }
+  } finally {
+    Pop-Location
+  }
+} finally {
+  if ($null -ne $backendProcess -and -not $backendProcess.HasExited) {
+    Stop-Process -Id $backendProcess.Id -Force
+  }
+
+  if ($startedEmulator) {
+    try {
+      & $script:AdbExecutable emu kill | Out-Null
+    } catch {
+    }
+  }
+}

--- a/scripts/mobile-e2e-server.ts
+++ b/scripts/mobile-e2e-server.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { app } from "@backend/app";
+import { PGlite } from "@electric-sql/pglite";
+import { serve } from "@hono/node-server";
+import * as schema from "@infra/drizzle/schema";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+
+import { seedDevData } from "./seedDevData";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+function loadEnvFile(filePath: string): Record<string, string> {
+  if (!fs.existsSync(filePath)) return {};
+
+  return fs
+    .readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .reduce<Record<string, string>>((acc, line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) return acc;
+
+      const separatorIndex = trimmed.indexOf("=");
+      if (separatorIndex < 0) return acc;
+
+      const key = trimmed.slice(0, separatorIndex).trim();
+      const value = trimmed.slice(separatorIndex + 1).trim();
+      if (!key) return acc;
+
+      acc[key] = value;
+      return acc;
+    }, {});
+}
+
+const backendEnv = loadEnvFile(path.join(repoRoot, "apps/backend/.env"));
+
+const migrationsFolder = "./infra/drizzle/migrations";
+const apiPort = Number(process.env.API_PORT ?? backendEnv.API_PORT ?? 3457);
+const appUrl =
+  process.env.APP_URL ?? backendEnv.APP_URL ?? "http://localhost:2540";
+const appUrlV2 = process.env.APP_URL_V2 ?? backendEnv.APP_URL_V2 ?? appUrl;
+
+let pglite: PGlite | null = null;
+let server: ReturnType<typeof serve> | null = null;
+
+async function closeServer(exitCode = 0) {
+  await new Promise<void>((resolve, reject) => {
+    if (!server) {
+      resolve();
+      return;
+    }
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+  await pglite?.close();
+  process.exit(exitCode);
+}
+
+async function main() {
+  pglite = new PGlite();
+  const db = drizzle(pglite, { schema });
+
+  await migrate(db, { migrationsFolder });
+  await seedDevData(db);
+
+  const testEnv = {
+    APP_URL: appUrl,
+    APP_URL_V2: appUrlV2,
+    JWT_AUDIENCE: "actiko-backend",
+    JWT_SECRET:
+      process.env.JWT_SECRET ??
+      backendEnv.JWT_SECRET ??
+      "e2e-test-secret-that-is-at-least-32-chars-long!!",
+    JWT_SECRET_ADMIN:
+      process.env.JWT_SECRET_ADMIN ?? backendEnv.JWT_SECRET_ADMIN,
+    NODE_ENV: "test" as const,
+    DATABASE_URL: "unused-pglite-in-memory",
+    GOOGLE_OAUTH_CLIENT_ID:
+      process.env.GOOGLE_OAUTH_CLIENT_ID ??
+      backendEnv.GOOGLE_OAUTH_CLIENT_ID ??
+      "dummy-string",
+    GOOGLE_OAUTH_CLIENT_ID_ANDROID:
+      process.env.GOOGLE_OAUTH_CLIENT_ID_ANDROID ??
+      backendEnv.GOOGLE_OAUTH_CLIENT_ID_ANDROID,
+    GOOGLE_OAUTH_CLIENT_ID_IOS:
+      process.env.GOOGLE_OAUTH_CLIENT_ID_IOS ??
+      backendEnv.GOOGLE_OAUTH_CLIENT_ID_IOS,
+    GOOGLE_OAUTH_CLIENT_SECRET:
+      process.env.GOOGLE_OAUTH_CLIENT_SECRET ??
+      backendEnv.GOOGLE_OAUTH_CLIENT_SECRET,
+    APPLE_TEAM_ID: process.env.APPLE_TEAM_ID ?? backendEnv.APPLE_TEAM_ID,
+    APPLE_KEY_ID: process.env.APPLE_KEY_ID ?? backendEnv.APPLE_KEY_ID,
+    APPLE_CLIENT_ID: process.env.APPLE_CLIENT_ID ?? backendEnv.APPLE_CLIENT_ID,
+    APPLE_BUNDLE_ID: process.env.APPLE_BUNDLE_ID ?? backendEnv.APPLE_BUNDLE_ID,
+    APPLE_PRIVATE_KEY:
+      process.env.APPLE_PRIVATE_KEY ?? backendEnv.APPLE_PRIVATE_KEY,
+    ADMIN_ALLOWED_EMAILS:
+      process.env.ADMIN_ALLOWED_EMAILS ?? backendEnv.ADMIN_ALLOWED_EMAILS,
+    CF_WORKERS_TOKEN:
+      process.env.CF_WORKERS_TOKEN ?? backendEnv.CF_WORKERS_TOKEN,
+    CF_ACCOUNT_ID: process.env.CF_ACCOUNT_ID ?? backendEnv.CF_ACCOUNT_ID,
+    STORAGE_TYPE: "local" as const,
+    UPLOAD_DIR: "public/uploads",
+    DB: db,
+    RATE_LIMIT_KV: undefined,
+    REDIS_URL: undefined,
+    OPENROUTER_API_KEY:
+      process.env.OPENROUTER_API_KEY ?? backendEnv.OPENROUTER_API_KEY,
+    AI_MODEL: process.env.AI_MODEL ?? backendEnv.AI_MODEL,
+    POLAR_WEBHOOK_SECRET:
+      process.env.POLAR_WEBHOOK_SECRET ?? backendEnv.POLAR_WEBHOOK_SECRET,
+    REVENUECAT_WEBHOOK_AUTH_KEY:
+      process.env.REVENUECAT_WEBHOOK_AUTH_KEY ??
+      backendEnv.REVENUECAT_WEBHOOK_AUTH_KEY ??
+      "rc_e2e_test_key",
+    POLAR_ACCESS_TOKEN:
+      process.env.POLAR_ACCESS_TOKEN ?? backendEnv.POLAR_ACCESS_TOKEN,
+    POLAR_PRICE_ID: process.env.POLAR_PRICE_ID ?? backendEnv.POLAR_PRICE_ID,
+  };
+
+  server = serve({
+    fetch: (request) => app.fetch(request, testEnv),
+    port: apiPort,
+  });
+
+  await new Promise<void>((resolve) => {
+    server?.on("listening", resolve);
+  });
+
+  console.log(`Mobile E2E backend running on http://localhost:${apiPort}`);
+  console.log("Login ID: e2e@example.com");
+  console.log("Password: password123");
+}
+
+main().catch(async (error) => {
+  console.error("Failed to start mobile E2E backend", error);
+  await closeServer(1);
+});
+
+process.on("SIGINT", () => {
+  void closeServer(0);
+});
+
+process.on("SIGTERM", () => {
+  void closeServer(0);
+});

--- a/scripts/mobile-e2e-server.ts
+++ b/scripts/mobile-e2e-server.ts
@@ -6,6 +6,7 @@ import { app } from "@backend/app";
 import { PGlite } from "@electric-sql/pglite";
 import { serve } from "@hono/node-server";
 import * as schema from "@infra/drizzle/schema";
+import { DEFAULT_DEV_API_PORT } from "@packages/platform";
 import { drizzle } from "drizzle-orm/pglite";
 import { migrate } from "drizzle-orm/pglite/migrator";
 
@@ -39,7 +40,9 @@ function loadEnvFile(filePath: string): Record<string, string> {
 const backendEnv = loadEnvFile(path.join(repoRoot, "apps/backend/.env"));
 
 const migrationsFolder = "./infra/drizzle/migrations";
-const apiPort = Number(process.env.API_PORT ?? backendEnv.API_PORT ?? 3457);
+const apiPort = Number(
+  process.env.API_PORT ?? backendEnv.API_PORT ?? DEFAULT_DEV_API_PORT,
+);
 const appUrl =
   process.env.APP_URL ?? backendEnv.APP_URL ?? "http://localhost:2540";
 const appUrlV2 = process.env.APP_URL_V2 ?? backendEnv.APP_URL_V2 ?? appUrl;
@@ -129,6 +132,7 @@ async function main() {
 
   server = serve({
     fetch: (request) => app.fetch(request, testEnv),
+    hostname: "127.0.0.1",
     port: apiPort,
   });
 

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -77,6 +77,10 @@ else
   git -C "$REPO_ROOT" worktree add "$WT_DIR" -b "wt/$NAME" 2>/dev/null \
     || git -C "$REPO_ROOT" worktree add "$WT_DIR" "wt/$NAME" 2>/dev/null \
     || git -C "$REPO_ROOT" worktree add --detach "$WT_DIR"
+  # Use a relative gitdir so the worktree is valid from both Windows and WSL.
+  if [ -f "$WT_DIR/.git" ]; then
+    printf 'gitdir: ../../.git/worktrees/%s\n' "$NAME" > "$WT_DIR/.git"
+  fi
   echo "  Created."
 fi
 
@@ -127,7 +131,23 @@ fi
 WT_MOBILE_DIR="$WT_DIR/apps/mobile"
 if [ -d "$WT_MOBILE_DIR" ]; then
   WT_MOBILE_ENV="$WT_MOBILE_DIR/.env"
-  echo "EXPO_PUBLIC_API_URL=http://localhost:$API_PORT" > "$WT_MOBILE_ENV"
+  MAIN_MOBILE_ENV="$REPO_ROOT/apps/mobile/.env"
+  MAIN_MOBILE_ENV_EXAMPLE="$REPO_ROOT/apps/mobile/.env.example"
+
+  if [ -f "$MAIN_MOBILE_ENV" ]; then
+    cp "$MAIN_MOBILE_ENV" "$WT_MOBILE_ENV"
+  elif [ -f "$MAIN_MOBILE_ENV_EXAMPLE" ]; then
+    cp "$MAIN_MOBILE_ENV_EXAMPLE" "$WT_MOBILE_ENV"
+  else
+    : > "$WT_MOBILE_ENV"
+  fi
+
+  if grep -q "^EXPO_PUBLIC_API_URL=" "$WT_MOBILE_ENV" 2>/dev/null; then
+    sed -i "s|^EXPO_PUBLIC_API_URL=.*|EXPO_PUBLIC_API_URL=http://localhost:$API_PORT|" "$WT_MOBILE_ENV"
+  else
+    echo "EXPO_PUBLIC_API_URL=http://localhost:$API_PORT" >> "$WT_MOBILE_ENV"
+  fi
+
   echo "  apps/mobile/.env → OK"
 fi
 


### PR DESCRIPTION
## Summary
- add Maestro smoke flows, stable mobile `testID`s, and task/login coverage for the Expo app
- add a local mobile E2E backend, Android API URL resolution, and a Windows runner script for Android smoke tests
- add EAS Android/iOS E2E workflows plus an Expo config plugin to enable Android cleartext traffic for managed E2E builds

## Verification
- `git diff --check`
- `pnpm --filter actiko-mobile typecheck`
- Windows Android Maestro smoke run via `scripts/mobile-e2e-android-windows.ps1`
  - EAS build: `f2ef14a4-da7c-41a2-a0fc-800cfb965d0c`
  - APK: `https://expo.dev/artifacts/eas/vZV1d1Bc5mt7to9K19LPyh.apk`
  - verified login -> Tasks tab -> create `e2e-smoke-task`
