### PR TITLE
ci(infra): restrict terraform workflow to master-base PRs

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -2,6 +2,8 @@ name: Infra (Terraform)
 
 on:
   pull_request:
+    branches:
+      - master
     paths:
       - 'terraform/**'
       - '.github/workflows/infra.yml'


### PR DESCRIPTION
## Summary

`.github/workflows/infra.yml` が master → release の累積リリースPRで毎回発火し、毎回CI失敗していた問題を解消。`pull_request` トリガーに `branches: [master]` を追加し、base=master のPRに限定した。

## 背景 / 原因

- 既存の `paths` フィルタは `terraform/**` と `.github/workflows/infra.yml` に限定されており一見正しい
- しかし `master → release` の**累積PR**（#202 等）は master 側のマージ毎に再同期され、過去の terraform 変更や `.github/workflows/infra.yml` 自身の変更（PR #200）が diff に残り続ける
- 結果 paths がマッチし続け、無関係なPRマージのたびに infra.yml が走る
- さらにその実行では secrets が未登録のため `terraform init` が `No valid credential sources found` で失敗

## 変更

```yaml
on:
  pull_request:
    branches:
      - master          # ← 追加
    paths:
      - 'terraform/**'
      - '.github/workflows/infra.yml'
```

## ⚠ レビュアー向け: 別途対処が必要な残件

infra.yml は現状そもそも動作可能な状態に**なっていない**。この PR のスコープ外だが、将来 terraform を触る PR が立つ前に以下が必要:

### 未登録の Repository secrets
- `TF_STATE_R2_ACCESS_KEY_ID`
- `TF_STATE_R2_SECRET_ACCESS_KEY`
- `TF_CLOUDFLARE_API_TOKEN`

（`CF_ACCOUNT_ID` / `KV_RATE_LIMIT_ID_STG` / `KV_RATE_LIMIT_ID_PROD` は登録済み）

### 未作成の GitHub Environment
workflow_dispatch job が `environment: infra-\${{ inputs.env }}` を参照しているが、`infra-stg` / `infra-prod` environment が未作成。apply / destroy に protection rule を掛ける前提なら作成必須。

## Test plan

- [ ] 本 PR (terraform 無変更) で infra.yml が **発火しない** ことを確認
- [ ] 今後 terraform/** を触るPRで発火すること（secrets 整備後）