### PR TITLE
Tighten boundary validation and nullable kind handling

### DIFF
--- a/apps/backend/feature-sync/activity-log/activityLogSyncRepository.ts
+++ b/apps/backend/feature-sync/activity-log/activityLogSyncRepository.ts
@@ -11,6 +11,11 @@ import { and, eq, gt, inArray, lt, sql } from "drizzle-orm";
 
 type ActivityLogRow = typeof activityLogs.$inferSelect;
 
+export type ActivityKindWithActivityId = {
+  id: string;
+  activityId: string;
+};
+
 export type ActivityLogSyncRepository = {
   getActivityLogsByUserId: (
     userId: UserId,
@@ -20,7 +25,10 @@ export type ActivityLogSyncRepository = {
     userId: UserId,
     activityIds: string[],
   ) => Promise<string[]>;
-  getExistingActivityKindIds: (kindIds: string[]) => Promise<string[]>;
+  getOwnedActivityKindIdsWithActivityId: (
+    userId: UserId,
+    kindIds: string[],
+  ) => Promise<ActivityKindWithActivityId[]>;
   getExistingTaskIds: (userId: UserId, taskIds: string[]) => Promise<string[]>;
   upsertActivityLogs: (
     userId: UserId,
@@ -38,7 +46,8 @@ export function newActivityLogSyncRepository(
   return {
     getActivityLogsByUserId: getActivityLogsByUserId(db),
     getOwnedActivityIds: getOwnedActivityIds(db),
-    getExistingActivityKindIds: getExistingActivityKindIds(db),
+    getOwnedActivityKindIdsWithActivityId:
+      getOwnedActivityKindIdsWithActivityId(db),
     getExistingTaskIds: getExistingTaskIds(db),
     upsertActivityLogs: upsertActivityLogs(db),
     getActivityLogsByIds: getActivityLogsByIds(db),
@@ -74,16 +83,20 @@ function getOwnedActivityIds(db: QueryExecutor) {
   };
 }
 
-function getExistingActivityKindIds(db: QueryExecutor) {
-  return async (kindIds: string[]): Promise<string[]> => {
+function getOwnedActivityKindIdsWithActivityId(db: QueryExecutor) {
+  return async (
+    userId: UserId,
+    kindIds: string[],
+  ): Promise<ActivityKindWithActivityId[]> => {
     if (kindIds.length === 0) return [];
 
-    const rows = await db
-      .select({ id: activityKinds.id })
+    return await db
+      .select({ id: activityKinds.id, activityId: activityKinds.activityId })
       .from(activityKinds)
-      .where(inArray(activityKinds.id, kindIds));
-
-    return rows.map((r) => r.id);
+      .innerJoin(activities, eq(activityKinds.activityId, activities.id))
+      .where(
+        and(inArray(activityKinds.id, kindIds), eq(activities.userId, userId)),
+      );
   };
 }
 

--- a/apps/backend/feature-sync/activity-log/activityLogSyncRoute.test.ts
+++ b/apps/backend/feature-sync/activity-log/activityLogSyncRoute.test.ts
@@ -169,6 +169,21 @@ describe("POST /users/v2/activity-logs/sync", () => {
     expect(json.skippedIds).toHaveLength(0);
   });
 
+  test("FK チェック - activityKindIdが別activityに属する場合はskip", async () => {
+    const app = createApp();
+    const log = makeLog({
+      activityId: "00000000-0000-4000-8000-000000000002",
+      activityKindId: SEED_ACTIVITY_KIND_ID,
+    });
+
+    const res = await postSync(app, { logs: [log] });
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+    expect(json.skippedIds).toContain(log.id);
+    expect(json.syncedIds).toHaveLength(0);
+  });
+
   test("バリデーションエラー - 必須フィールド欠損", async () => {
     const app = createApp();
     const res = await postSync(app, {

--- a/apps/backend/feature-sync/activity-log/activityLogSyncUsecase.test.ts
+++ b/apps/backend/feature-sync/activity-log/activityLogSyncUsecase.test.ts
@@ -53,7 +53,11 @@ function createMockRepo(
   return {
     getActivityLogsByUserId: vi.fn().mockResolvedValue([]),
     getOwnedActivityIds: vi.fn().mockResolvedValue([OWNED_ACTIVITY_ID]),
-    getExistingActivityKindIds: vi.fn().mockResolvedValue([OWNED_KIND_ID]),
+    getOwnedActivityKindIdsWithActivityId: vi
+      .fn()
+      .mockResolvedValue([
+        { id: OWNED_KIND_ID, activityId: OWNED_ACTIVITY_ID },
+      ]),
     getExistingTaskIds: vi.fn().mockResolvedValue([OWNED_TASK_ID]),
     upsertActivityLogs: vi.fn().mockResolvedValue([]),
     getActivityLogsByIds: vi.fn().mockResolvedValue([]),
@@ -152,7 +156,28 @@ describe("activityLogSyncUsecase", () => {
         activityKindId: "99999999-9999-4999-9999-999999999999",
       });
       const repo = createMockRepo({
-        getExistingActivityKindIds: vi.fn().mockResolvedValue([]),
+        getOwnedActivityKindIdsWithActivityId: vi.fn().mockResolvedValue([]),
+      });
+      const usecase = newActivityLogSyncUsecase(repo, noopTracer);
+
+      const result = await usecase.syncActivityLogs(USER_ID, [req as never]);
+
+      expect(result.skippedIds).toContain(req.id);
+      expect(repo.upsertActivityLogs).not.toHaveBeenCalled();
+    });
+
+    test("activityKindIdが別activityに属する → skip", async () => {
+      const otherActivityId = "00000000-0000-4000-8000-000000000099";
+      const req = makeUpsertRequest({
+        activityId: OWNED_ACTIVITY_ID,
+        activityKindId: OWNED_KIND_ID,
+      });
+      const repo = createMockRepo({
+        getOwnedActivityKindIdsWithActivityId: vi
+          .fn()
+          .mockResolvedValue([
+            { id: OWNED_KIND_ID, activityId: otherActivityId },
+          ]),
       });
       const usecase = newActivityLogSyncUsecase(repo, noopTracer);
 

--- a/apps/backend/feature-sync/activity-log/activityLogSyncUsecase.ts
+++ b/apps/backend/feature-sync/activity-log/activityLogSyncUsecase.ts
@@ -60,7 +60,7 @@ function syncActivityLogs(repo: ActivityLogSyncRepository, tracer: Tracer) {
     );
     const ownedActivityIdSet = new Set(ownedIds);
 
-    // FK existence check for activityKindId and taskId
+    // FK / ownership check for activityKindId and taskId
     const requestedKindIds = [
       ...new Set(logs.map((l) => l.activityKindId).filter(Boolean)),
     ] as string[];
@@ -68,15 +68,17 @@ function syncActivityLogs(repo: ActivityLogSyncRepository, tracer: Tracer) {
       ...new Set(logs.map((l) => l.taskId).filter(Boolean)),
     ] as string[];
 
-    const [existingKindIds, existingTaskIds] = await Promise.all([
-      tracer.span("db.getExistingActivityKindIds", () =>
-        repo.getExistingActivityKindIds(requestedKindIds),
+    const [ownedKindRows, existingTaskIds] = await Promise.all([
+      tracer.span("db.getOwnedActivityKindIdsWithActivityId", () =>
+        repo.getOwnedActivityKindIdsWithActivityId(userId, requestedKindIds),
       ),
       tracer.span("db.getExistingTaskIds", () =>
         repo.getExistingTaskIds(userId, requestedTaskIds),
       ),
     ]);
-    const existingKindIdSet = new Set(existingKindIds);
+    const kindIdToActivityId = new Map(
+      ownedKindRows.map((r) => [r.id, r.activityId]),
+    );
     const existingTaskIdSet = new Set(existingTaskIds);
 
     const maxAllowed = new Date(Date.now() + 5 * 60 * 1000);
@@ -85,7 +87,9 @@ function syncActivityLogs(repo: ActivityLogSyncRepository, tracer: Tracer) {
       if (
         !ownedActivityIdSet.has(log.activityId) ||
         new Date(log.updatedAt) > maxAllowed ||
-        (log.activityKindId && !existingKindIdSet.has(log.activityKindId)) ||
+        (log.activityKindId &&
+          (!kindIdToActivityId.has(log.activityKindId) ||
+            kindIdToActivityId.get(log.activityKindId) !== log.activityId)) ||
         (log.taskId && !existingTaskIdSet.has(log.taskId))
       ) {
         skippedIds.push(log.id);

--- a/apps/backend/feature-sync/task/taskSyncRoute.test.ts
+++ b/apps/backend/feature-sync/task/taskSyncRoute.test.ts
@@ -125,6 +125,19 @@ describe("POST /users/v2/tasks/sync", () => {
     expect(res.status).toBe(400);
   });
 
+  test("バリデーションエラー - activityKindIdにactivityIdが必要", async () => {
+    const app = createApp();
+    const res = await postSync(app, {
+      tasks: [
+        makeTask({
+          activityId: null,
+          activityKindId: "00000000-0000-4000-8000-000000000001",
+        }),
+      ],
+    });
+    expect(res.status).toBe(400);
+  });
+
   test("複数タスクの一括同期", async () => {
     const app = createApp();
     const tasks = [

--- a/apps/backend/feature-sync/task/taskSyncUsecase.test.ts
+++ b/apps/backend/feature-sync/task/taskSyncUsecase.test.ts
@@ -319,26 +319,24 @@ describe("taskSyncUsecase", () => {
       expect(repo.upsertTasks).not.toHaveBeenCalled();
     });
 
-    test("activityKindIdあり + activityId null → 所有権のみチェックで通る", async () => {
+    test("activityKindIdあり + activityId null → skip", async () => {
       const req = makeUpsertRequest({
         activityId: null,
         activityKindId: OWNED_KIND_ID,
       });
-      const row = makeTaskRow({ activityKindId: OWNED_KIND_ID });
       const repo = createMockRepo({
         getOwnedActivityKindIdsWithActivityId: vi
           .fn()
           .mockResolvedValue([
             { id: OWNED_KIND_ID, activityId: OWNED_ACTIVITY_ID },
           ]),
-        upsertTasks: vi.fn().mockResolvedValue([row]),
       });
       const usecase = newTaskSyncUsecase(repo, noopTracer);
 
       const result = await usecase.syncTasks(USER_ID, [req as never]);
 
-      expect(result.syncedIds).toContain(req.id);
-      expect(result.skippedIds).toHaveLength(0);
+      expect(result.skippedIds).toContain(req.id);
+      expect(repo.upsertTasks).not.toHaveBeenCalled();
     });
 
     test("activityKindIdが他人のもの + activityId null → skip", async () => {

--- a/apps/backend/feature-sync/task/taskSyncUsecase.ts
+++ b/apps/backend/feature-sync/task/taskSyncUsecase.ts
@@ -80,9 +80,9 @@ function syncTasks(repo: TaskSyncRepository, tracer: Tracer) {
         new Date(task.updatedAt) > maxAllowed ||
         (task.activityId && !ownedActivityIdSet.has(task.activityId)) ||
         (task.activityKindId &&
-          (!kindIdToActivityId.has(task.activityKindId) ||
-            (task.activityId &&
-              kindIdToActivityId.get(task.activityKindId) !== task.activityId)))
+          (!task.activityId ||
+            !kindIdToActivityId.has(task.activityKindId) ||
+            kindIdToActivityId.get(task.activityKindId) !== task.activityId))
       ) {
         skippedIds.push(task.id);
         return false;

--- a/apps/backend/feature/activityLog/activityLogBatchUsecase.ts
+++ b/apps/backend/feature/activityLog/activityLogBatchUsecase.ts
@@ -24,6 +24,17 @@ type CreateActivityLogParams = {
   activityKindId?: string | null;
 };
 
+function toBatchErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return "Failed to create activity logs";
+  if (
+    error.message.startsWith("Activity not found:") ||
+    error.message.startsWith("Activity kind not found:")
+  ) {
+    return error.message;
+  }
+  return "Failed to create activity logs";
+}
+
 export function createActivityLogBatch(
   repo: ActivityLogRepository,
   acRepo: ActivityRepository,
@@ -114,7 +125,7 @@ export function createActivityLogBatch(
       const results = activityLogs.map((_, index) => ({
         index,
         success: false,
-        error: error instanceof Error ? error.message : "Unknown error",
+        error: toBatchErrorMessage(error),
       }));
 
       return {

--- a/apps/backend/feature/activityLog/activityLogBatchUsecase.ts
+++ b/apps/backend/feature/activityLog/activityLogBatchUsecase.ts
@@ -20,8 +20,8 @@ type CreateActivityLogParams = {
   date: string;
   quantity: number;
   memo?: string;
-  activityId?: string;
-  activityKindId?: string;
+  activityId: string;
+  activityKindId?: string | null;
 };
 
 export function createActivityLogBatch(
@@ -52,26 +52,39 @@ export function createActivityLogBatch(
 
         for (const params of activityLogs) {
           const activityId = createActivityId(params.activityId);
-          const activityKindId = createActivityKindId(params.activityKindId);
+          const activityKindId =
+            params.activityKindId == null
+              ? null
+              : createActivityKindId(params.activityKindId);
 
           const activity = activityMap.get(activityId);
           if (!activity) {
             throw new Error(`Activity not found: ${params.activityId}`);
           }
 
-          if (!activity.kinds) activity.kinds = [];
-
+          const activityForLog = { ...activity, kinds: activity.kinds ?? [] };
           const activityKind =
-            activity.kinds.find((kind) => kind.id === activityKindId) || null;
+            activityKindId === null
+              ? null
+              : (activityForLog.kinds.find(
+                  (kind) => kind.id === activityKindId,
+                ) ?? null);
+          if (activityKindId !== null && activityKind === null) {
+            throw new Error(
+              `Activity kind not found: ${params.activityKindId}`,
+            );
+          }
 
           const activityLog = createActivityLogEntity({
-            id: createActivityLogId(),
+            id: params.id
+              ? createActivityLogId(params.id)
+              : createActivityLogId(),
             userId,
             date: new Date(params.date),
             quantity: params.quantity,
             memo: params.memo,
-            activity,
-            activityKind: activityKind!,
+            activity: activityForLog,
+            activityKind,
             type: "new",
           });
 

--- a/apps/backend/feature/activityLog/activityLogHandler.ts
+++ b/apps/backend/feature/activityLog/activityLogHandler.ts
@@ -71,7 +71,10 @@ function getActivityLog(uc: ActivityLogUsecase) {
 function createActivityLog(uc: ActivityLogUsecase) {
   return async (userId: UserId, params: CreateActivityLogRequest) => {
     const activityId = createActivityId(params.activityId);
-    const activityKindId = createActivityKindId(params.activityKindId);
+    const activityKindId =
+      params.activityKindId == null
+        ? null
+        : createActivityKindId(params.activityKindId);
 
     const log = await uc.createActivityLog(
       userId,

--- a/apps/backend/feature/activityLog/activityLogMutationUsecase.ts
+++ b/apps/backend/feature/activityLog/activityLogMutationUsecase.ts
@@ -14,7 +14,7 @@ import type { ActivityLogRepository } from "./activityLogRepository";
 type UpdateActivityLogParams = {
   quantity?: number;
   memo?: string;
-  activityKindId?: string;
+  activityKindId?: string | null;
 };
 
 export function updateActivityLog(
@@ -35,21 +35,30 @@ export function updateActivityLog(
       throw new ResourceNotFoundError("activity log not found");
     }
 
-    const activityKindParent = params.activityKindId
-      ? await tracer.span("db.getActivityByUserIdAndActivityKindId", () =>
-          acRepo.getActivityByUserIdAndActivityKindId(
-            userId,
-            createActivityKindId(params.activityKindId!),
-          ),
-        )
-      : { kinds: [activityLog.activityKind] };
-    if (!activityKindParent) {
-      throw new ResourceNotFoundError("activity kind not found");
-    }
+    let activityKind = activityLog.activityKind ?? null;
 
-    const activityKind =
-      activityKindParent.kinds.find((ak) => ak?.id === params.activityKindId) ||
-      null;
+    if (params.activityKindId !== undefined) {
+      if (params.activityKindId === null) {
+        activityKind = null;
+      } else {
+        const activityKindId = createActivityKindId(params.activityKindId);
+        const activityKindParent = await tracer.span(
+          "db.getActivityByUserIdAndActivityKindId",
+          () =>
+            acRepo.getActivityByUserIdAndActivityKindId(userId, activityKindId),
+        );
+        if (!activityKindParent) {
+          throw new ResourceNotFoundError("activity kind not found");
+        }
+
+        activityKind =
+          activityKindParent.kinds.find((ak) => ak?.id === activityKindId) ??
+          null;
+        if (activityKind === null) {
+          throw new ResourceNotFoundError("activity kind not found");
+        }
+      }
+    }
 
     const newActivityLog = createActivityLogEntity({
       ...activityLog,

--- a/apps/backend/feature/activityLog/activityLogMutationUsecase.ts
+++ b/apps/backend/feature/activityLog/activityLogMutationUsecase.ts
@@ -50,6 +50,9 @@ export function updateActivityLog(
         if (!activityKindParent) {
           throw new ResourceNotFoundError("activity kind not found");
         }
+        if (activityKindParent.id !== activityLog.activity.id) {
+          throw new ResourceNotFoundError("activity kind not found");
+        }
 
         activityKind =
           activityKindParent.kinds.find((ak) => ak?.id === activityKindId) ??

--- a/apps/backend/feature/activityLog/activityLogUsecase.ts
+++ b/apps/backend/feature/activityLog/activityLogUsecase.ts
@@ -1,3 +1,4 @@
+import { ResourceNotFoundError } from "@backend/error";
 import type { QueryExecutor } from "@backend/infra/rdb/drizzle";
 import type { Tracer } from "@backend/lib/tracer";
 import type { ActivityQueryService } from "@backend/query";
@@ -41,8 +42,11 @@ type CreateActivityLogParams = {
   date: string;
   quantity: number;
   memo?: string;
-  activityId?: string;
-  activityKindId?: string;
+  activityKindId?: string | null;
+};
+
+type CreateActivityLogBatchParams = CreateActivityLogParams & {
+  activityId: string;
 };
 
 export type ActivityLogUsecase = {
@@ -57,17 +61,21 @@ export type ActivityLogUsecase = {
   createActivityLog: (
     userId: UserId,
     activityId: ActivityId,
-    activityKindId: ActivityKindId,
+    activityKindId: ActivityKindId | null,
     params: CreateActivityLogParams,
   ) => Promise<ActivityLog>;
   createActivityLogBatch: (
     userId: UserId,
-    activityLogs: CreateActivityLogParams[],
+    activityLogs: CreateActivityLogBatchParams[],
   ) => Promise<CreateActivityLogBatchResponse>;
   updateActivityLog: (
     userId: UserId,
     activityLogId: ActivityLogId,
-    params: { quantity?: number; memo?: string; activityKindId?: string },
+    params: {
+      quantity?: number;
+      memo?: string;
+      activityKindId?: string | null;
+    },
   ) => Promise<ActivityLog>;
   deleteActivityLog: (
     userId: UserId,
@@ -114,7 +122,7 @@ function createActivityLog(
   return async (
     userId: UserId,
     activityId: ActivityId,
-    activityKindId: ActivityKindId,
+    activityKindId: ActivityKindId | null,
     params: CreateActivityLogParams,
   ) => {
     const activity = await tracer.span("db.getActivityByIdAndUserId", () =>
@@ -122,10 +130,15 @@ function createActivityLog(
     );
     if (!activity) throw new Error("activity not found");
 
-    if (!activity.kinds) activity.kinds = [];
-
+    const activityForLog = { ...activity, kinds: activity.kinds ?? [] };
     const activityKind =
-      activity.kinds.find((kind) => kind.id === activityKindId) || null;
+      activityKindId === null
+        ? null
+        : (activityForLog.kinds.find((kind) => kind.id === activityKindId) ??
+          null);
+    if (activityKindId !== null && activityKind === null) {
+      throw new ResourceNotFoundError("activity kind not found");
+    }
 
     const activityLog = createActivityLogEntity({
       id: params.id ? createActivityLogId(params.id) : createActivityLogId(),
@@ -133,8 +146,8 @@ function createActivityLog(
       date: new Date(params.date),
       quantity: params.quantity,
       memo: params.memo,
-      activity,
-      activityKind: activityKind!,
+      activity: activityForLog,
+      activityKind,
       type: "new",
     });
 

--- a/apps/backend/feature/activityLog/test/activityLogRoute.test.ts
+++ b/apps/backend/feature/activityLog/test/activityLogRoute.test.ts
@@ -20,6 +20,21 @@ test("GET activityLogs / success", async () => {
   expect(res.status).toEqual(200);
 });
 
+test("GET activityLogs / invalid date で 400", async () => {
+  const route = createActivityLogRoute();
+  const app = newHonoWithErrorHandling()
+    .use(mockAuthMiddleware)
+    .route("/", route);
+
+  const res = await app.request(
+    "/?date=2026-02-30",
+    { method: "GET" },
+    { DB: testDB, NODE_ENV: "test" },
+  );
+
+  expect(res.status).toEqual(400);
+});
+
 test("GET activityLogs/:id / success", async () => {
   const route = createActivityLogRoute();
   const app = new Hono().use(mockAuthMiddleware).route("/", route);

--- a/apps/backend/feature/activityLog/test/activityLogUsecase.test.ts
+++ b/apps/backend/feature/activityLog/test/activityLogUsecase.test.ts
@@ -236,7 +236,7 @@ describe("ActivityLogUsecase", () => {
       name: string;
       userId: UserId;
       activityId: ActivityId;
-      activityKindId: ActivityKindId;
+      activityKindId: ActivityKindId | null;
       params: {
         date: string;
         quantity: number;
@@ -358,6 +358,44 @@ describe("ActivityLogUsecase", () => {
         });
       },
     );
+
+    it("アクティビティ種別なしでログを作成できる", async () => {
+      when(acRepo.getActivityByIdAndUserId(userId1, activityId1)).thenResolve(
+        mockActivity,
+      );
+      when(repo.createActivityLog(anything())).thenCall((log) => log);
+
+      const result = await usecase.createActivityLog(
+        userId1,
+        activityId1,
+        null,
+        {
+          date: "2025-01-01",
+          quantity: 5,
+        },
+      );
+
+      expect(result.activityKind).toBeNull();
+      verify(repo.createActivityLog(anything())).once();
+    });
+
+    it("指定したアクティビティ種別が存在しない場合は作成しない", async () => {
+      const missingKindId = createActivityKindId(
+        "00000000-0000-4000-8000-000000000004",
+      );
+      when(acRepo.getActivityByIdAndUserId(userId1, activityId1)).thenResolve(
+        mockActivity,
+      );
+
+      await expect(
+        usecase.createActivityLog(userId1, activityId1, missingKindId, {
+          date: "2025-01-01",
+          quantity: 5,
+        }),
+      ).rejects.toThrow(ResourceNotFoundError);
+
+      verify(repo.createActivityLog(anything())).never();
+    });
   });
 
   describe("updateActivityLog", () => {
@@ -368,6 +406,7 @@ describe("ActivityLogUsecase", () => {
       params: {
         quantity?: number;
         memo?: string;
+        activityKindId?: string | null;
       };
       existingActivityLog: ActivityLog | undefined;
       updatedActivityLog: ActivityLog | undefined;
@@ -471,6 +510,58 @@ describe("ActivityLogUsecase", () => {
         });
       },
     );
+
+    it("activityKindId未指定の更新では既存の種別を保持する", async () => {
+      when(
+        repo.getActivityLogByIdAndUserId(userId1, activityLogId1),
+      ).thenResolve(mockActivityLog);
+      when(repo.updateActivityLog(anything())).thenCall((log) => log);
+
+      const result = await usecase.updateActivityLog(userId1, activityLogId1, {
+        quantity: 7,
+      });
+
+      expect(result.activityKind).toEqual(mockActivityKind);
+      verify(repo.updateActivityLog(anything())).once();
+      verify(
+        acRepo.getActivityByUserIdAndActivityKindId(userId1, anything()),
+      ).never();
+    });
+
+    it("activityKindId null の更新では種別を明示的に解除する", async () => {
+      when(
+        repo.getActivityLogByIdAndUserId(userId1, activityLogId1),
+      ).thenResolve(mockActivityLog);
+      when(repo.updateActivityLog(anything())).thenCall((log) => log);
+
+      const result = await usecase.updateActivityLog(userId1, activityLogId1, {
+        activityKindId: null,
+      });
+
+      expect(result.activityKind).toBeNull();
+      verify(repo.updateActivityLog(anything())).once();
+    });
+
+    it("存在しないactivityKindIdへの更新では保存しない", async () => {
+      const missingKindId = "00000000-0000-4000-8000-000000000004";
+      when(
+        repo.getActivityLogByIdAndUserId(userId1, activityLogId1),
+      ).thenResolve(mockActivityLog);
+      when(
+        acRepo.getActivityByUserIdAndActivityKindId(
+          userId1,
+          createActivityKindId(missingKindId),
+        ),
+      ).thenResolve(undefined);
+
+      await expect(
+        usecase.updateActivityLog(userId1, activityLogId1, {
+          activityKindId: missingKindId,
+        }),
+      ).rejects.toThrow(ResourceNotFoundError);
+
+      verify(repo.updateActivityLog(anything())).never();
+    });
   });
 
   describe("deleteActivityLog", () => {
@@ -631,7 +722,7 @@ describe("ActivityLogUsecase", () => {
         quantity: number;
         memo?: string;
         activityId: string;
-        activityKindId?: string;
+        activityKindId?: string | null;
       }>;
       mockActivities: Array<Activity | undefined>;
       mockCreatedLogs: ActivityLog[];
@@ -821,7 +912,7 @@ describe("ActivityLogUsecase", () => {
       },
     );
 
-    it("アクティビティ種別が存在しない場合でも正常に処理される", async () => {
+    it("activityKindIdなしなら種別なしログとして処理される", async () => {
       const activityWithoutKinds: Activity = {
         ...mockActivity,
         kinds: undefined as unknown as ActivityKind[],
@@ -850,12 +941,39 @@ describe("ActivityLogUsecase", () => {
           date: "2025-01-01",
           quantity: 5,
           activityId: activityId1,
-          activityKindId: activityKindId1,
         },
       ]);
 
       expect(result.summary.succeeded).toBe(1);
       expect(result.summary.failed).toBe(0);
+    });
+
+    it("指定したactivityKindIdが存在しない場合はバッチ全体を失敗にする", async () => {
+      const txRepo = mock<ActivityLogRepository>();
+      const txAcRepo = mock<ActivityRepository>();
+
+      when(repo.withTx(anything())).thenReturn(instance(txRepo));
+      when(acRepo.withTx(anything())).thenReturn(instance(txAcRepo));
+      when(
+        txAcRepo.getActivitiesByIdsAndUserId(userId1, anything()),
+      ).thenResolve([mockActivity]);
+      when(db.transaction(anything())).thenCall(async (callback) => {
+        return callback({ withTx: () => {} } as unknown as QueryExecutor);
+      });
+
+      const result = await usecase.createActivityLogBatch(userId1, [
+        {
+          date: "2025-01-01",
+          quantity: 5,
+          activityId: activityId1,
+          activityKindId: "00000000-0000-4000-8000-000000000004",
+        },
+      ]);
+
+      expect(result.summary.succeeded).toBe(0);
+      expect(result.summary.failed).toBe(1);
+      expect(result.results[0].error).toContain("Activity kind not found");
+      verify(txRepo.createActivityLogBatch(anything())).never();
     });
 
     it("空の配列を渡した場合は空の結果を返す", async () => {

--- a/apps/backend/feature/activityLog/test/activityLogUsecase.test.ts
+++ b/apps/backend/feature/activityLog/test/activityLogUsecase.test.ts
@@ -562,6 +562,34 @@ describe("ActivityLogUsecase", () => {
 
       verify(repo.updateActivityLog(anything())).never();
     });
+
+    it("別アクティビティ配下のactivityKindIdへの更新では保存しない", async () => {
+      const otherActivityId = createActivityId(
+        "00000000-0000-4000-8000-000000000006",
+      );
+      const otherKindId = createActivityKindId(
+        "00000000-0000-4000-8000-000000000007",
+      );
+      const otherActivity: Activity = {
+        ...mockActivity,
+        id: otherActivityId,
+        kinds: [{ id: otherKindId, name: "Walk", orderIndex: "1" }],
+      };
+      when(
+        repo.getActivityLogByIdAndUserId(userId1, activityLogId1),
+      ).thenResolve(mockActivityLog);
+      when(
+        acRepo.getActivityByUserIdAndActivityKindId(userId1, otherKindId),
+      ).thenResolve(otherActivity);
+
+      await expect(
+        usecase.updateActivityLog(userId1, activityLogId1, {
+          activityKindId: otherKindId,
+        }),
+      ).rejects.toThrow(ResourceNotFoundError);
+
+      verify(repo.updateActivityLog(anything())).never();
+    });
   });
 
   describe("deleteActivityLog", () => {
@@ -867,6 +895,9 @@ describe("ActivityLogUsecase", () => {
             expect(result.summary.failed).toBe(activityLogs.length);
             expect(result.summary.succeeded).toBe(0);
             expect(result.results.every((r) => !r.success)).toBe(true);
+            expect(result.results[0].error).toBe(
+              "Failed to create activity logs",
+            );
             return;
           }
 

--- a/apps/backend/feature/goal/goalRoute.ts
+++ b/apps/backend/feature/goal/goalRoute.ts
@@ -9,6 +9,7 @@ import {
 } from "@packages/types/request";
 
 import type { AppContext } from "../../context";
+import { newActivityRepository } from "../activity/activityRepository";
 import { newActivityGoalRepository } from "../activitygoal/activityGoalRepository";
 import { newActivityGoalService } from "../activitygoal/activityGoalService";
 import { newActivityLogRepository } from "../activityLog/activityLogRepository";
@@ -29,6 +30,7 @@ export function createGoalRoute() {
 
     // Repository instances
     const activityGoalRepo = newActivityGoalRepository(db);
+    const activityRepo = newActivityRepository(db);
     const activityLogRepo = newActivityLogRepository(db);
 
     // Service instances
@@ -39,6 +41,7 @@ export function createGoalRoute() {
     const tracer = c.get("tracer") ?? noopTracer;
     const uc = newGoalUsecase(
       activityGoalRepo,
+      activityRepo,
       activityGoalService,
       activityLogRepo,
       tracer,

--- a/apps/backend/feature/goal/goalUsecase.ts
+++ b/apps/backend/feature/goal/goalUsecase.ts
@@ -3,6 +3,7 @@ import type { Tracer } from "@backend/lib/tracer";
 import { createActivityGoalId } from "@packages/domain/goal/goalSchema";
 import type { UserId } from "@packages/domain/user/userSchema";
 
+import type { ActivityRepository } from "../activity/activityRepository";
 import type { ActivityGoalRepository } from "../activitygoal/activityGoalRepository";
 import type { ActivityGoalService } from "../activitygoal/activityGoalService";
 import { prefetchActivityLogs } from "../activitygoal/activityGoalService";
@@ -20,6 +21,7 @@ export type {
 
 export function newGoalUsecase(
   activityGoalRepo: ActivityGoalRepository,
+  activityRepo: ActivityRepository,
   activityGoalService: ActivityGoalService,
   activityLogRepo: ActivityLogRepository,
   tracer: Tracer,
@@ -32,7 +34,7 @@ export function newGoalUsecase(
       tracer,
     ),
     getGoal: getGoal(activityGoalRepo, activityGoalService, tracer),
-    createGoal: createGoal(activityGoalRepo, tracer),
+    createGoal: createGoal(activityGoalRepo, activityRepo, tracer),
     updateGoal: updateGoal(activityGoalRepo, tracer),
     deleteGoal: deleteGoal(activityGoalRepo, tracer),
   };

--- a/apps/backend/feature/goal/goalWriteUsecase.ts
+++ b/apps/backend/feature/goal/goalWriteUsecase.ts
@@ -1,4 +1,4 @@
-import { ResourceNotFoundError } from "@backend/error";
+import { AppError, ResourceNotFoundError } from "@backend/error";
 import type { Tracer } from "@backend/lib/tracer";
 import { createActivityId } from "@packages/domain/activity/activitySchema";
 import { parseDayTargets } from "@packages/domain/goal/dayTargets";
@@ -12,11 +12,19 @@ import type { ActivityGoalRepository } from "../activitygoal/activityGoalReposit
 import type { CreateGoalRequest, Goal, UpdateGoalRequest } from "./goalTypes";
 import { goalEntityToResponse } from "./goalTypes";
 
+function assertGoalDateRange(startDate: string, endDate: string | null) {
+  if (endDate !== null && endDate < startDate) {
+    throw new AppError("endDate must be on or after startDate", 400);
+  }
+}
+
 export function createGoal(
   activityGoalRepo: ActivityGoalRepository,
   tracer: Tracer,
 ) {
   return async (userId: UserId, req: CreateGoalRequest): Promise<Goal> => {
+    assertGoalDateRange(req.startDate, req.endDate ?? null);
+
     const goal = createActivityGoalEntity({
       type: "new",
       id: createActivityGoalId(),
@@ -60,11 +68,15 @@ export function updateGoal(
     );
     if (!goal) throw new ResourceNotFoundError("Goal not found");
 
+    const startDate = req.startDate ?? goal.startDate;
+    const endDate = req.endDate === null ? null : (req.endDate ?? goal.endDate);
+    assertGoalDateRange(startDate, endDate);
+
     const updated = createActivityGoalEntity({
       ...goal,
       dailyTargetQuantity: req.dailyTargetQuantity ?? goal.dailyTargetQuantity,
-      startDate: req.startDate ?? goal.startDate,
-      endDate: req.endDate === null ? null : (req.endDate ?? goal.endDate),
+      startDate,
+      endDate,
       description:
         req.description === null ? null : (req.description ?? goal.description),
       isActive: req.isActive ?? goal.isActive,

--- a/apps/backend/feature/goal/goalWriteUsecase.ts
+++ b/apps/backend/feature/goal/goalWriteUsecase.ts
@@ -8,6 +8,7 @@ import {
 } from "@packages/domain/goal/goalSchema";
 import type { UserId } from "@packages/domain/user/userSchema";
 
+import type { ActivityRepository } from "../activity/activityRepository";
 import type { ActivityGoalRepository } from "../activitygoal/activityGoalRepository";
 import type { CreateGoalRequest, Goal, UpdateGoalRequest } from "./goalTypes";
 import { goalEntityToResponse } from "./goalTypes";
@@ -20,16 +21,25 @@ function assertGoalDateRange(startDate: string, endDate: string | null) {
 
 export function createGoal(
   activityGoalRepo: ActivityGoalRepository,
+  activityRepo: ActivityRepository,
   tracer: Tracer,
 ) {
   return async (userId: UserId, req: CreateGoalRequest): Promise<Goal> => {
     assertGoalDateRange(req.startDate, req.endDate ?? null);
+    const activityId = createActivityId(req.activityId);
+
+    const activity = await tracer.span("db.getActivityByIdAndUserId", () =>
+      activityRepo.getActivityByIdAndUserId(userId, activityId),
+    );
+    if (!activity) {
+      throw new AppError("activityId does not belong to user", 400);
+    }
 
     const goal = createActivityGoalEntity({
       type: "new",
       id: createActivityGoalId(),
       userId,
-      activityId: createActivityId(req.activityId),
+      activityId,
       dailyTargetQuantity: req.dailyTargetQuantity,
       startDate: req.startDate,
       endDate: req.endDate || null,

--- a/apps/backend/feature/goal/test/goalUsecase.test.ts
+++ b/apps/backend/feature/goal/test/goalUsecase.test.ts
@@ -336,6 +336,22 @@ describe("GoalUsecase", () => {
       expect(result.dayTargets).toEqual({ 1: 5, 2: 10 });
       verify(activityGoalRepo.createActivityGoal(anything())).once();
     });
+
+    it("should reject a goal whose endDate is before startDate", async () => {
+      const userId = createUserId();
+      const activityId = createActivityId();
+      const request: CreateGoalRequest = {
+        activityId,
+        dailyTargetQuantity: 10,
+        startDate: "2024-02-01",
+        endDate: "2024-01-31",
+      };
+
+      await expect(usecase.createGoal(userId, request)).rejects.toThrow(
+        "endDate must be on or after startDate",
+      );
+      verify(activityGoalRepo.createActivityGoal(anything())).never();
+    });
   });
 
   describe("updateGoal", () => {
@@ -462,6 +478,38 @@ describe("GoalUsecase", () => {
       await expect(usecase.updateGoal(userId, goalId, {})).rejects.toThrow(
         ResourceNotFoundError,
       );
+    });
+
+    it("should reject an update that makes the date range invalid", async () => {
+      const userId = createUserId();
+      const goalId = "00000000-0000-4000-8000-000000000001";
+      const activityId = createActivityId();
+
+      const existingGoal = createActivityGoalEntity({
+        type: "persisted",
+        id: goalId as ActivityGoalId,
+        userId,
+        activityId,
+        dailyTargetQuantity: 10,
+        startDate: "2024-01-01",
+        endDate: "2024-01-31",
+        isActive: true,
+        description: null,
+        debtCap: null,
+        dayTargets: null,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      });
+
+      when(
+        activityGoalRepo.getActivityGoalByIdAndUserId(anything(), userId),
+      ).thenResolve(existingGoal);
+
+      await expect(
+        usecase.updateGoal(userId, goalId, { startDate: "2024-02-01" }),
+      ).rejects.toThrow("endDate must be on or after startDate");
+
+      verify(activityGoalRepo.updateActivityGoal(anything())).never();
     });
   });
 

--- a/apps/backend/feature/goal/test/goalUsecase.test.ts
+++ b/apps/backend/feature/goal/test/goalUsecase.test.ts
@@ -1,6 +1,10 @@
 import { ResourceNotFoundError } from "@backend/error";
 import { noopTracer } from "@backend/lib/tracer";
-import { createActivityId } from "@packages/domain/activity/activitySchema";
+import {
+  type Activity,
+  type ActivityId,
+  createActivityId,
+} from "@packages/domain/activity/activitySchema";
 import {
   type ActivityGoalId,
   type GoalBalance,
@@ -10,6 +14,7 @@ import { createUserId } from "@packages/domain/user/userSchema";
 import { anything, instance, mock, reset, verify, when } from "ts-mockito";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import type { ActivityRepository } from "../../activity";
 import type { ActivityGoalRepository } from "../../activitygoal/activityGoalRepository";
 import type { ActivityGoalService } from "../../activitygoal/activityGoalService";
 import type { ActivityLogRepository } from "../../activityLog";
@@ -22,26 +27,51 @@ import { newGoalUsecase } from "../goalUsecase";
 
 describe("GoalUsecase", () => {
   let activityGoalRepo: ActivityGoalRepository;
+  let activityRepo: ActivityRepository;
   let activityGoalService: ActivityGoalService;
   let activityLogRepo: ActivityLogRepository;
   let usecase: ReturnType<typeof newGoalUsecase>;
 
   beforeEach(() => {
     activityGoalRepo = mock<ActivityGoalRepository>();
+    activityRepo = mock<ActivityRepository>();
     activityGoalService = mock<ActivityGoalService>();
     activityLogRepo = mock<ActivityLogRepository>();
 
     reset(activityGoalRepo);
+    reset(activityRepo);
     reset(activityGoalService);
     reset(activityLogRepo);
 
     usecase = newGoalUsecase(
       instance(activityGoalRepo),
+      instance(activityRepo),
       instance(activityGoalService),
       instance(activityLogRepo),
       noopTracer,
     );
   });
+
+  function makeActivity(
+    userId: ReturnType<typeof createUserId>,
+    id: ActivityId,
+  ): Activity {
+    return {
+      id,
+      userId,
+      name: "Running",
+      quantityUnit: "km",
+      orderIndex: "1",
+      kinds: [],
+      type: "new",
+      showCombinedStats: true,
+      iconType: "emoji",
+      emoji: null,
+      iconUrl: null,
+      iconThumbnailUrl: null,
+      recordingMode: "manual",
+    };
+  }
 
   describe("getGoals", () => {
     it("should return goals with balance information", async () => {
@@ -274,6 +304,9 @@ describe("GoalUsecase", () => {
         description: "New goal",
       };
 
+      when(
+        activityRepo.getActivityByIdAndUserId(userId, activityId),
+      ).thenResolve(makeActivity(userId, activityId));
       when(activityGoalRepo.createActivityGoal(anything())).thenResolve(
         createActivityGoalEntity({
           type: "persisted",
@@ -312,6 +345,9 @@ describe("GoalUsecase", () => {
         dayTargets: { "1": 5, "2": 10 },
       };
 
+      when(
+        activityRepo.getActivityByIdAndUserId(userId, activityId),
+      ).thenResolve(makeActivity(userId, activityId));
       when(activityGoalRepo.createActivityGoal(anything())).thenResolve(
         createActivityGoalEntity({
           type: "persisted",
@@ -335,6 +371,25 @@ describe("GoalUsecase", () => {
       expect(result.debtCap).toBe(30);
       expect(result.dayTargets).toEqual({ 1: 5, 2: 10 });
       verify(activityGoalRepo.createActivityGoal(anything())).once();
+    });
+
+    it("should reject a goal whose activity does not belong to the user", async () => {
+      const userId = createUserId();
+      const activityId = createActivityId();
+      const request: CreateGoalRequest = {
+        activityId,
+        dailyTargetQuantity: 10,
+        startDate: "2024-01-01",
+      };
+
+      when(
+        activityRepo.getActivityByIdAndUserId(userId, activityId),
+      ).thenResolve(undefined);
+
+      await expect(usecase.createGoal(userId, request)).rejects.toThrow(
+        "activityId does not belong to user",
+      );
+      verify(activityGoalRepo.createActivityGoal(anything())).never();
     });
 
     it("should reject a goal whose endDate is before startDate", async () => {
@@ -510,6 +565,45 @@ describe("GoalUsecase", () => {
       ).rejects.toThrow("endDate must be on or after startDate");
 
       verify(activityGoalRepo.updateActivityGoal(anything())).never();
+    });
+
+    it("should preserve omitted endDate and clear explicit null endDate", async () => {
+      const userId = createUserId();
+      const goalId = "00000000-0000-4000-8000-000000000001";
+      const activityId = createActivityId();
+      const existingGoal = createActivityGoalEntity({
+        type: "persisted",
+        id: goalId as ActivityGoalId,
+        userId,
+        activityId,
+        dailyTargetQuantity: 10,
+        startDate: "2024-01-01",
+        endDate: "2024-01-31",
+        isActive: true,
+        description: null,
+        debtCap: null,
+        dayTargets: null,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      });
+
+      when(
+        activityGoalRepo.getActivityGoalByIdAndUserId(anything(), userId),
+      ).thenResolve(existingGoal);
+      when(activityGoalRepo.updateActivityGoal(anything())).thenCall(
+        (goal) => goal,
+      );
+
+      const preserved = await usecase.updateGoal(userId, goalId, {
+        description: "updated",
+      });
+      const cleared = await usecase.updateGoal(userId, goalId, {
+        endDate: null,
+      });
+
+      expect(preserved.endDate).toBe("2024-01-31");
+      expect(cleared.endDate).toBeUndefined();
+      verify(activityGoalRepo.updateActivityGoal(anything())).twice();
     });
   });
 

--- a/apps/backend/feature/goalFreezePeriod/goalFreezePeriodUsecase.ts
+++ b/apps/backend/feature/goalFreezePeriod/goalFreezePeriodUsecase.ts
@@ -1,4 +1,4 @@
-import { ResourceNotFoundError } from "@backend/error";
+import { AppError, ResourceNotFoundError } from "@backend/error";
 import type { Tracer } from "@backend/lib/tracer";
 import type { UserId } from "@packages/domain/user/userSchema";
 
@@ -55,6 +55,15 @@ function recordToFreezePeriod(record: GoalFreezePeriodRecord): FreezePeriod {
   };
 }
 
+function assertFreezePeriodDateRange(
+  startDate: string,
+  endDate: string | null,
+) {
+  if (endDate !== null && endDate < startDate) {
+    throw new AppError("endDate must be on or after startDate", 400);
+  }
+}
+
 export function newGoalFreezePeriodUsecase(
   repo: GoalFreezePeriodRepository,
   tracer: Tracer,
@@ -92,6 +101,8 @@ function createFreezePeriod(repo: GoalFreezePeriodRepository, tracer: Tracer) {
     );
     if (!isOwned) throw new ResourceNotFoundError("Goal not found");
 
+    assertFreezePeriodDateRange(params.startDate, params.endDate);
+
     const record = await tracer.span("db.createGoalFreezePeriod", () =>
       repo.createGoalFreezePeriod(
         userId,
@@ -119,6 +130,11 @@ function updateFreezePeriod(repo: GoalFreezePeriodRepository, tracer: Tracer) {
     if (existing.goalId !== goalId) {
       throw new ResourceNotFoundError("Freeze period not found");
     }
+
+    const startDate = params.startDate ?? existing.startDate;
+    const endDate =
+      params.endDate === undefined ? existing.endDate : params.endDate;
+    assertFreezePeriodDateRange(startDate, endDate);
 
     const record = await tracer.span("db.updateGoalFreezePeriod", () =>
       repo.updateGoalFreezePeriod(id, userId, {

--- a/apps/backend/feature/goalFreezePeriod/test/goalFreezePeriodUsecase.test.ts
+++ b/apps/backend/feature/goalFreezePeriod/test/goalFreezePeriodUsecase.test.ts
@@ -63,4 +63,56 @@ describe("GoalFreezePeriodUsecase", () => {
       repo.updateGoalFreezePeriod(anything(), anything(), anything()),
     ).never();
   });
+
+  it("updateFreezePeriod preserves omitted endDate and clears explicit null endDate", async () => {
+    when(repo.getFreezePeriodByIdAndUserId(freezePeriodId, userId)).thenResolve(
+      {
+        id: freezePeriodId,
+        goalId,
+        userId,
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    );
+    when(repo.updateGoalFreezePeriod(freezePeriodId, userId, anything()))
+      .thenResolve({
+        id: freezePeriodId,
+        goalId,
+        userId,
+        startDate: "2026-01-10",
+        endDate: "2026-01-31",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      })
+      .thenResolve({
+        id: freezePeriodId,
+        goalId,
+        userId,
+        startDate: "2026-01-01",
+        endDate: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      });
+
+    const preserved = await usecase.updateFreezePeriod(
+      userId,
+      goalId,
+      freezePeriodId,
+      { startDate: "2026-01-10" },
+    );
+    const cleared = await usecase.updateFreezePeriod(
+      userId,
+      goalId,
+      freezePeriodId,
+      { endDate: null },
+    );
+
+    expect(preserved.endDate).toBe("2026-01-31");
+    expect(cleared.endDate).toBeNull();
+    verify(
+      repo.updateGoalFreezePeriod(freezePeriodId, userId, anything()),
+    ).twice();
+  });
 });

--- a/apps/backend/feature/goalFreezePeriod/test/goalFreezePeriodUsecase.test.ts
+++ b/apps/backend/feature/goalFreezePeriod/test/goalFreezePeriodUsecase.test.ts
@@ -1,0 +1,66 @@
+import { noopTracer } from "@backend/lib/tracer";
+import { createUserId } from "@packages/domain/user/userSchema";
+import { anything, instance, mock, reset, verify, when } from "ts-mockito";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { GoalFreezePeriodRepository } from "../goalFreezePeriodRepository";
+import { newGoalFreezePeriodUsecase } from "../goalFreezePeriodUsecase";
+
+describe("GoalFreezePeriodUsecase", () => {
+  let repo: GoalFreezePeriodRepository;
+  let usecase: ReturnType<typeof newGoalFreezePeriodUsecase>;
+
+  const userId = createUserId("00000000-0000-4000-8000-000000000000");
+  const goalId = "00000000-0000-4000-8000-000000000001";
+  const freezePeriodId = "00000000-0000-4000-8000-000000000002";
+
+  beforeEach(() => {
+    repo = mock<GoalFreezePeriodRepository>();
+    usecase = newGoalFreezePeriodUsecase(instance(repo), noopTracer);
+    reset(repo);
+  });
+
+  it("createFreezePeriod rejects endDate before startDate", async () => {
+    when(repo.isGoalOwnedByUser(goalId, userId)).thenResolve(true);
+
+    await expect(
+      usecase.createFreezePeriod(userId, goalId, {
+        startDate: "2026-01-10",
+        endDate: "2026-01-09",
+      }),
+    ).rejects.toThrow("endDate must be on or after startDate");
+
+    verify(
+      repo.createGoalFreezePeriod(
+        anything(),
+        anything(),
+        anything(),
+        anything(),
+      ),
+    ).never();
+  });
+
+  it("updateFreezePeriod rejects a range made invalid by existing values", async () => {
+    when(repo.getFreezePeriodByIdAndUserId(freezePeriodId, userId)).thenResolve(
+      {
+        id: freezePeriodId,
+        goalId,
+        userId,
+        startDate: "2026-01-01",
+        endDate: "2026-01-31",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    );
+
+    await expect(
+      usecase.updateFreezePeriod(userId, goalId, freezePeriodId, {
+        startDate: "2026-02-01",
+      }),
+    ).rejects.toThrow("endDate must be on or after startDate");
+
+    verify(
+      repo.updateGoalFreezePeriod(anything(), anything(), anything()),
+    ).never();
+  });
+});

--- a/apps/backend/feature/task/taskRoute.ts
+++ b/apps/backend/feature/task/taskRoute.ts
@@ -10,6 +10,7 @@ import {
 import { getTasksRequestSchema } from "@packages/types/request/GetTasksRequest";
 
 import type { AppContext } from "../../context";
+import { newActivityRepository } from "../activity/activityRepository";
 import { newTaskHandler } from "./taskHandler";
 import { newTaskRepository } from "./taskRepository";
 import { newTaskUsecase } from "./taskUsecase";
@@ -28,7 +29,8 @@ export function createTaskRoute() {
 
     const tracer = c.get("tracer") ?? noopTracer;
     const repo = newTaskRepository(db);
-    const uc = newTaskUsecase(repo, tracer);
+    const activityRepo = newActivityRepository(db);
+    const uc = newTaskUsecase(repo, activityRepo, tracer);
     const h = newTaskHandler(uc);
 
     c.set("h", h);

--- a/apps/backend/feature/task/taskUsecase.ts
+++ b/apps/backend/feature/task/taskUsecase.ts
@@ -1,6 +1,10 @@
 import { AppError, ResourceNotFoundError } from "@backend/error";
 import type { Tracer } from "@backend/lib/tracer";
 import {
+  createActivityId,
+  createActivityKindId,
+} from "@packages/domain/activity/activitySchema";
+import {
   type Task,
   type TaskId,
   createTaskEntity,
@@ -8,6 +12,7 @@ import {
 } from "@packages/domain/task/taskSchema";
 import type { UserId } from "@packages/domain/user/userSchema";
 
+import type { ActivityRepository } from "../activity/activityRepository";
 import type { TaskRepository } from ".";
 
 export type CreateTaskInputParams = {
@@ -56,17 +61,48 @@ function assertTaskDateRange(
 
 export function newTaskUsecase(
   repo: TaskRepository,
+  activityRepo: ActivityRepository,
   tracer: Tracer,
 ): TaskUsecase {
   return {
     getTasks: getTasks(repo, tracer),
     getArchivedTasks: getArchivedTasks(repo, tracer),
     getTask: getTask(repo, tracer),
-    createTask: createTask(repo, tracer),
-    updateTask: updateTask(repo, tracer),
+    createTask: createTask(repo, activityRepo, tracer),
+    updateTask: updateTask(repo, activityRepo, tracer),
     deleteTask: deleteTask(repo, tracer),
     archiveTask: archiveTask(repo, tracer),
   };
+}
+
+async function assertTaskActivityLink(
+  activityRepo: ActivityRepository,
+  tracer: Tracer,
+  userId: UserId,
+  activityId: string | null | undefined,
+  activityKindId: string | null | undefined,
+) {
+  if (activityKindId != null && activityId == null) {
+    throw new AppError("activityKindId requires activityId", 400);
+  }
+  if (activityId == null) return;
+
+  const ownedActivityId = createActivityId(activityId);
+  const activity = await tracer.span("db.getActivityByIdAndUserId", () =>
+    activityRepo.getActivityByIdAndUserId(userId, ownedActivityId),
+  );
+  if (!activity) {
+    throw new AppError("activityId does not belong to user", 400);
+  }
+  if (activityKindId == null) return;
+
+  const ownedActivityKindId = createActivityKindId(activityKindId);
+  const hasKind = activity.kinds.some(
+    (kind) => kind.id === ownedActivityKindId,
+  );
+  if (!hasKind) {
+    throw new AppError("activityKindId does not belong to activity", 400);
+  }
 }
 
 function getTasks(repo: TaskRepository, tracer: Tracer) {
@@ -96,16 +132,29 @@ function getTask(repo: TaskRepository, tracer: Tracer) {
   };
 }
 
-function createTask(repo: TaskRepository, tracer: Tracer) {
+function createTask(
+  repo: TaskRepository,
+  activityRepo: ActivityRepository,
+  tracer: Tracer,
+) {
   return async (userId: UserId, params: CreateTaskInputParams) => {
     assertTaskDateRange(params.startDate, params.dueDate);
+    const activityId = params.activityId ?? null;
+    const activityKindId = params.activityKindId ?? null;
+    await assertTaskActivityLink(
+      activityRepo,
+      tracer,
+      userId,
+      activityId,
+      activityKindId,
+    );
 
     const task = createTaskEntity({
       type: "new",
       id: createTaskId(),
       userId: userId,
-      activityId: params.activityId || null,
-      activityKindId: params.activityKindId || null,
+      activityId,
+      activityKindId,
       quantity: params.quantity ?? null,
       title: params.title,
       startDate: params.startDate || null,
@@ -119,7 +168,11 @@ function createTask(repo: TaskRepository, tracer: Tracer) {
   };
 }
 
-function updateTask(repo: TaskRepository, tracer: Tracer) {
+function updateTask(
+  repo: TaskRepository,
+  activityRepo: ActivityRepository,
+  tracer: Tracer,
+) {
   return async (
     userId: UserId,
     taskId: TaskId,
@@ -143,9 +196,32 @@ function updateTask(repo: TaskRepository, tracer: Tracer) {
       params.dueDate === undefined ? task.dueDate : params.dueDate;
     assertTaskDateRange(startDate, dueDate);
 
+    const activityIdChanged = params.activityId !== undefined;
+    const activityId =
+      params.activityId === undefined
+        ? (task.activityId ?? null)
+        : params.activityId;
+    const activityKindId =
+      params.activityKindId !== undefined
+        ? params.activityKindId
+        : activityIdChanged
+          ? null
+          : (task.activityKindId ?? null);
+    if (activityIdChanged || params.activityKindId !== undefined) {
+      await assertTaskActivityLink(
+        activityRepo,
+        tracer,
+        userId,
+        activityId,
+        activityKindId,
+      );
+    }
+
     const newTask = createTaskEntity({
       ...task,
       ...params,
+      activityId,
+      activityKindId,
     });
 
     const updateTask = await tracer.span("db.updateTask", () =>

--- a/apps/backend/feature/task/taskUsecase.ts
+++ b/apps/backend/feature/task/taskUsecase.ts
@@ -1,4 +1,4 @@
-import { ResourceNotFoundError } from "@backend/error";
+import { AppError, ResourceNotFoundError } from "@backend/error";
 import type { Tracer } from "@backend/lib/tracer";
 import {
   type Task,
@@ -45,6 +45,15 @@ export type TaskUsecase = {
   archiveTask: (userId: UserId, taskId: TaskId) => Promise<Task>;
 };
 
+function assertTaskDateRange(
+  startDate: string | null | undefined,
+  dueDate: string | null | undefined,
+) {
+  if (startDate != null && dueDate != null && dueDate < startDate) {
+    throw new AppError("dueDate must be on or after startDate", 400);
+  }
+}
+
 export function newTaskUsecase(
   repo: TaskRepository,
   tracer: Tracer,
@@ -89,6 +98,8 @@ function getTask(repo: TaskRepository, tracer: Tracer) {
 
 function createTask(repo: TaskRepository, tracer: Tracer) {
   return async (userId: UserId, params: CreateTaskInputParams) => {
+    assertTaskDateRange(params.startDate, params.dueDate);
+
     const task = createTaskEntity({
       type: "new",
       id: createTaskId(),
@@ -126,6 +137,11 @@ function updateTask(repo: TaskRepository, tracer: Tracer) {
       // 実際にはここに到達しないが、型安全性のため
       throw new ResourceNotFoundError("updateTaskUsecase:task not found");
     }
+
+    const startDate = params.startDate ?? task.startDate;
+    const dueDate =
+      params.dueDate === undefined ? task.dueDate : params.dueDate;
+    assertTaskDateRange(startDate, dueDate);
 
     const newTask = createTaskEntity({
       ...task,

--- a/apps/backend/feature/task/test/taskUsecase.test.ts
+++ b/apps/backend/feature/task/test/taskUsecase.test.ts
@@ -1,6 +1,13 @@
 import { ResourceNotFoundError } from "@backend/error";
 import { noopTracer } from "@backend/lib/tracer";
 import {
+  type Activity,
+  type ActivityId,
+  type ActivityKindId,
+  createActivityId,
+  createActivityKindId,
+} from "@packages/domain/activity/activitySchema";
+import {
   type Task,
   type TaskId,
   createTaskId,
@@ -9,21 +16,59 @@ import { type UserId, createUserId } from "@packages/domain/user/userSchema";
 import { anything, instance, mock, reset, verify, when } from "ts-mockito";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import type { ActivityRepository } from "../../activity";
 import { type TaskRepository, newTaskUsecase } from "..";
 
 describe("TaskUsecase", () => {
   let repo: TaskRepository;
+  let activityRepo: ActivityRepository;
   let usecase: ReturnType<typeof newTaskUsecase>;
 
   beforeEach(() => {
     repo = mock<TaskRepository>();
-    usecase = newTaskUsecase(instance(repo), noopTracer);
+    activityRepo = mock<ActivityRepository>();
+    usecase = newTaskUsecase(
+      instance(repo),
+      instance(activityRepo),
+      noopTracer,
+    );
     reset(repo);
+    reset(activityRepo);
   });
 
   const userId1 = createUserId("00000000-0000-4000-8000-000000000000");
   const taskId1 = createTaskId("00000000-0000-4000-8000-000000000001");
   const taskId2 = createTaskId("00000000-0000-4000-8000-000000000002");
+  const activityId1 = createActivityId("00000000-0000-4000-8000-000000000003");
+  const activityId2 = createActivityId("00000000-0000-4000-8000-000000000004");
+  const activityKindId1 = createActivityKindId(
+    "00000000-0000-4000-8000-000000000005",
+  );
+
+  function makeActivity(
+    id: ActivityId,
+    kindIds: ActivityKindId[] = [],
+  ): Activity {
+    return {
+      id,
+      userId: userId1,
+      name: "Running",
+      quantityUnit: "km",
+      orderIndex: "1",
+      kinds: kindIds.map((kindId, index) => ({
+        id: kindId,
+        name: `Kind ${index}`,
+        orderIndex: String(index),
+      })),
+      type: "new",
+      showCombinedStats: true,
+      iconType: "emoji",
+      emoji: null,
+      iconUrl: null,
+      iconThumbnailUrl: null,
+      recordingMode: "manual",
+    };
+  }
 
   describe("getTasks", () => {
     type GetTasksTestCase = {
@@ -230,6 +275,48 @@ describe("TaskUsecase", () => {
 
       verify(repo.createTask(anything())).never();
     });
+
+    it("failed / activityId does not belong to user", async () => {
+      when(
+        activityRepo.getActivityByIdAndUserId(userId1, activityId1),
+      ).thenResolve(undefined);
+
+      await expect(
+        usecase.createTask(userId1, {
+          title: "new task",
+          activityId: activityId1,
+        }),
+      ).rejects.toThrow("activityId does not belong to user");
+
+      verify(repo.createTask(anything())).never();
+    });
+
+    it("failed / activityKindId requires activityId", async () => {
+      await expect(
+        usecase.createTask(userId1, {
+          title: "new task",
+          activityKindId: activityKindId1,
+        }),
+      ).rejects.toThrow("activityKindId requires activityId");
+
+      verify(repo.createTask(anything())).never();
+    });
+
+    it("failed / activityKindId does not belong to activity", async () => {
+      when(
+        activityRepo.getActivityByIdAndUserId(userId1, activityId1),
+      ).thenResolve(makeActivity(activityId1));
+
+      await expect(
+        usecase.createTask(userId1, {
+          title: "new task",
+          activityId: activityId1,
+          activityKindId: activityKindId1,
+        }),
+      ).rejects.toThrow("activityKindId does not belong to activity");
+
+      verify(repo.createTask(anything())).never();
+    });
   });
 
   describe("updateTask", () => {
@@ -417,6 +504,93 @@ describe("TaskUsecase", () => {
       ).rejects.toThrow("dueDate must be on or after startDate");
 
       verify(repo.updateTask(anything())).never();
+    });
+
+    it("activityId null clears existing activityKindId", async () => {
+      const existingTask: Task = {
+        id: taskId1,
+        userId: userId1,
+        title: "title",
+        activityId: activityId1,
+        activityKindId: activityKindId1,
+        doneDate: null,
+        memo: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        type: "persisted",
+      };
+      when(repo.getTaskByUserIdAndTaskId(userId1, taskId1)).thenResolve(
+        existingTask,
+      );
+      when(repo.updateTask(anything())).thenCall((task) => task);
+
+      const result = await usecase.updateTask(userId1, taskId1, {
+        activityId: null,
+      });
+
+      expect(result.activityId).toBeNull();
+      expect(result.activityKindId).toBeNull();
+      verify(repo.updateTask(anything())).once();
+    });
+
+    it("activityId change with omitted activityKindId clears old kind", async () => {
+      const existingTask: Task = {
+        id: taskId1,
+        userId: userId1,
+        title: "title",
+        activityId: activityId1,
+        activityKindId: activityKindId1,
+        doneDate: null,
+        memo: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        type: "persisted",
+      };
+      when(repo.getTaskByUserIdAndTaskId(userId1, taskId1)).thenResolve(
+        existingTask,
+      );
+      when(
+        activityRepo.getActivityByIdAndUserId(userId1, activityId2),
+      ).thenResolve(makeActivity(activityId2));
+      when(repo.updateTask(anything())).thenCall((task) => task);
+
+      const result = await usecase.updateTask(userId1, taskId1, {
+        activityId: activityId2,
+      });
+
+      expect(result.activityId).toBe(activityId2);
+      expect(result.activityKindId).toBeNull();
+      verify(repo.updateTask(anything())).once();
+    });
+
+    it("dueDate undefined keeps existing dueDate and dueDate null clears it", async () => {
+      const existingTask: Task = {
+        id: taskId1,
+        userId: userId1,
+        title: "title",
+        doneDate: null,
+        memo: null,
+        startDate: "2021-01-01",
+        dueDate: "2021-01-31",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        type: "persisted",
+      };
+      when(repo.getTaskByUserIdAndTaskId(userId1, taskId1)).thenResolve(
+        existingTask,
+      );
+      when(repo.updateTask(anything())).thenCall((task) => task);
+
+      const kept = await usecase.updateTask(userId1, taskId1, {
+        title: "updated",
+      });
+      const cleared = await usecase.updateTask(userId1, taskId1, {
+        dueDate: null,
+      });
+
+      expect(kept.dueDate).toBe("2021-01-31");
+      expect(cleared.dueDate).toBeNull();
+      verify(repo.updateTask(anything())).twice();
     });
   });
 

--- a/apps/backend/feature/task/test/taskUsecase.test.ts
+++ b/apps/backend/feature/task/test/taskUsecase.test.ts
@@ -169,7 +169,7 @@ describe("TaskUsecase", () => {
     type CreateTaskTestCase = {
       name: string;
       userId: UserId;
-      inputParams: { title: string };
+      inputParams: { title: string; startDate?: string; dueDate?: string };
       mockReturn: Task | undefined;
       expectError: boolean;
     };
@@ -218,6 +218,18 @@ describe("TaskUsecase", () => {
         });
       },
     );
+
+    it("failed / dueDate before startDate", async () => {
+      await expect(
+        usecase.createTask(userId1, {
+          title: "new task",
+          startDate: "2021-01-10",
+          dueDate: "2021-01-09",
+        }),
+      ).rejects.toThrow("dueDate must be on or after startDate");
+
+      verify(repo.createTask(anything())).never();
+    });
   });
 
   describe("updateTask", () => {
@@ -230,6 +242,8 @@ describe("TaskUsecase", () => {
         title?: string;
         doneDate?: string | null;
         memo?: string | null;
+        startDate?: string;
+        dueDate?: string | null;
       };
       updatedTask: Task | undefined;
       expectError?: {
@@ -379,6 +393,31 @@ describe("TaskUsecase", () => {
         });
       },
     );
+
+    it("failed / update makes dueDate before startDate", async () => {
+      const existingTask: Task = {
+        id: taskId1,
+        userId: userId1,
+        title: "title",
+        doneDate: null,
+        memo: null,
+        startDate: "2021-01-01",
+        dueDate: "2021-01-31",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        type: "persisted",
+      };
+
+      when(repo.getTaskByUserIdAndTaskId(userId1, taskId1)).thenResolve(
+        existingTask,
+      );
+
+      await expect(
+        usecase.updateTask(userId1, taskId1, { startDate: "2021-02-01" }),
+      ).rejects.toThrow("dueDate must be on or after startDate");
+
+      verify(repo.updateTask(anything())).never();
+    });
   });
 
   describe("deleteTask", () => {

--- a/apps/backend/feature/task/test/taskUsecase.test.ts
+++ b/apps/backend/feature/task/test/taskUsecase.test.ts
@@ -291,6 +291,22 @@ describe("TaskUsecase", () => {
       verify(repo.createTask(anything())).never();
     });
 
+    it("success / owned activityId is kept", async () => {
+      when(
+        activityRepo.getActivityByIdAndUserId(userId1, activityId1),
+      ).thenResolve(makeActivity(activityId1));
+      when(repo.createTask(anything())).thenCall((task) => task);
+
+      const result = await usecase.createTask(userId1, {
+        title: "new task",
+        activityId: activityId1,
+      });
+
+      expect(result.activityId).toBe(activityId1);
+      expect(result.activityKindId).toBeNull();
+      verify(repo.createTask(anything())).once();
+    });
+
     it("failed / activityKindId requires activityId", async () => {
       await expect(
         usecase.createTask(userId1, {
@@ -316,6 +332,23 @@ describe("TaskUsecase", () => {
       ).rejects.toThrow("activityKindId does not belong to activity");
 
       verify(repo.createTask(anything())).never();
+    });
+
+    it("success / activityKindId belongs to activity", async () => {
+      when(
+        activityRepo.getActivityByIdAndUserId(userId1, activityId1),
+      ).thenResolve(makeActivity(activityId1, [activityKindId1]));
+      when(repo.createTask(anything())).thenCall((task) => task);
+
+      const result = await usecase.createTask(userId1, {
+        title: "new task",
+        activityId: activityId1,
+        activityKindId: activityKindId1,
+      });
+
+      expect(result.activityId).toBe(activityId1);
+      expect(result.activityKindId).toBe(activityKindId1);
+      verify(repo.createTask(anything())).once();
     });
   });
 
@@ -560,6 +593,36 @@ describe("TaskUsecase", () => {
 
       expect(result.activityId).toBe(activityId2);
       expect(result.activityKindId).toBeNull();
+      verify(repo.updateTask(anything())).once();
+    });
+
+    it("activityKindId can be set when it belongs to current activity", async () => {
+      const existingTask: Task = {
+        id: taskId1,
+        userId: userId1,
+        title: "title",
+        activityId: activityId1,
+        activityKindId: null,
+        doneDate: null,
+        memo: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        type: "persisted",
+      };
+      when(repo.getTaskByUserIdAndTaskId(userId1, taskId1)).thenResolve(
+        existingTask,
+      );
+      when(
+        activityRepo.getActivityByIdAndUserId(userId1, activityId1),
+      ).thenResolve(makeActivity(activityId1, [activityKindId1]));
+      when(repo.updateTask(anything())).thenCall((task) => task);
+
+      const result = await usecase.updateTask(userId1, taskId1, {
+        activityKindId: activityKindId1,
+      });
+
+      expect(result.activityId).toBe(activityId1);
+      expect(result.activityKindId).toBe(activityKindId1);
       verify(repo.updateTask(anything())).once();
     });
 

--- a/apps/frontend/src/components/api-reference/apiReferenceData.generated.ts
+++ b/apps/frontend/src/components/api-reference/apiReferenceData.generated.ts
@@ -50,7 +50,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
         queryParams: [
           {
             name: "date",
-            type: "string",
+            type: "union",
             required: false,
             description: "YYYY-MM-DD（日）または YYYY-MM（月）。省略時は今日",
           },
@@ -64,7 +64,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
         queryParams: [
           {
             name: "date",
-            type: "string",
+            type: "union",
             required: true,
             description: "YYYY-MM-DD（日）または YYYY-MM（月）",
           },
@@ -86,7 +86,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
             name: "id",
             type: "string",
             required: false,
-            description: "クライアント側ID（最大100文字）",
+            description: "クライアント側ID",
           },
           {
             name: "quantity",
@@ -109,7 +109,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
           {
             name: "activityId",
             type: "string",
-            required: false,
+            required: true,
             description: "アクティビティID",
           },
           {

--- a/apps/frontend/src/components/api-reference/apiReferenceData.generated.ts
+++ b/apps/frontend/src/components/api-reference/apiReferenceData.generated.ts
@@ -114,7 +114,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
           },
           {
             name: "activityKindId",
-            type: "string",
+            type: "string | null",
             required: false,
             description: "アクティビティ種別ID",
           },
@@ -155,7 +155,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
           },
           {
             name: "activityKindId",
-            type: "string",
+            type: "string | null",
             required: false,
             description: "アクティビティ種別ID",
           },
@@ -264,19 +264,19 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
           },
           {
             name: "activityId",
-            type: "string",
+            type: "string | null",
             required: false,
             description: "アクティビティID",
           },
           {
             name: "activityKindId",
-            type: "string",
+            type: "string | null",
             required: false,
             description: "アクティビティ種別ID",
           },
           {
             name: "quantity",
-            type: "number",
+            type: "number | null",
             required: false,
             description: "目標数量",
           },
@@ -294,13 +294,13 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
           },
           {
             name: "dueDate",
-            type: "string",
+            type: "string | null",
             required: false,
             description: "期限日（nullで解除）",
           },
           {
             name: "doneDate",
-            type: "string",
+            type: "string | null",
             required: false,
             description: "完了日（nullで未完了に戻す）",
           },

--- a/apps/frontend/src/components/api-reference/apiReferenceData.generated.ts
+++ b/apps/frontend/src/components/api-reference/apiReferenceData.generated.ts
@@ -50,7 +50,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
         queryParams: [
           {
             name: "date",
-            type: "union",
+            type: "string",
             required: false,
             description: "YYYY-MM-DD（日）または YYYY-MM（月）。省略時は今日",
           },
@@ -64,7 +64,7 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
         queryParams: [
           {
             name: "date",
-            type: "union",
+            type: "string",
             required: true,
             description: "YYYY-MM-DD（日）または YYYY-MM（月）",
           },

--- a/biome.json
+++ b/biome.json
@@ -12,8 +12,10 @@
       "!**/*.gen.ts",
       "!**/*.js",
       "!**/db-data",
+      "!apps/mobile/dist",
       "!**/stats.html",
-      "!.worktrees"
+      "!.worktrees",
+      "!.claude/worktrees"
     ]
   },
   "formatter": {

--- a/docs/diary-codex/20260425.md
+++ b/docs/diary-codex/20260425.md
@@ -1,0 +1,21 @@
+# 2026-04-25
+
+今日は、この repo の AI 開発運用そのものを評価するところから始まって、そのまま境界バリデーションの修正、PR 作成、CI 対応、multi-review、review-cycle、最後に Biome の対象外設定まで進んだ。作業量は多かったが、テーマは一貫していた。「型で逃げず、入力制約を境界に寄せる」という一点だった。
+
+最初のコードリーディング評価では、quality-scan を使わずに、ADR、日記、型、schema、usecase、sync 周りを見た。ユーザーが求めていたのは単なる褒め/批評ではなく、AI を導くエンジニアの力量まで含めた実態評価だった。そこに対して、設計や判断はかなり強い一方で、実装では nullable や日付、所有境界を型や後段に任せている箇所が残っていると見た。この指摘はそのまま次の修正対象になったので、評価と実装が地続きだった。
+
+最初の修正では date schema を `z.iso.date()` に寄せ、Goal / FreezePeriod / Task の日付範囲を schema と usecase の両方で固め、ActivityLog や Task の `activityId` / `activityKindId` も uuid と所有関係で縛った。ここで CI が `apiReferenceData.generated.ts` の未再生成で落ちたのは、完全にこちらの抜けだった。生成ファイルを持つ repo では、schema を触った時点で生成物まで差分に含めるのが当たり前だ。`pnpm run generate:api-reference` を後から回して直したが、最初の PR に入れておくべきだった。
+
+multi-review はかなり効いた。特に ActivityLog の更新で、別 Activity 配下の kind を許していた指摘は重要だった。自分では「ユーザー所有の kind か」を見て満足しかけていたが、実際には「そのログの Activity 配下か」まで見る必要がある。Goal 作成の `activityId` 所有確認、Task の `activityId` / `activityKindId` の親子関係、Task 更新で Activity を変えた時に古い kind が残る問題も同じ種類の抜けだった。型上は整っていても、境界の不変条件としては弱かった。
+
+その後の追加レビューで sync 経路が刺されたのも妥当だった。REST や batch だけを固めても、sync が同じ状態を保存できるなら抜け道として残る。ActivityLog sync が kind のグローバル存在だけを見ていたのは危険で、他ユーザーや別 Activity の kind metadata を混ぜられる可能性があった。Task sync も `activityKindId` と `activityId: null` の組み合わせを通せた。これは「境界に寄せる」と言っている作業としては見落としが大きい。最初から sync を同じ write boundary として扱うべきだった。
+
+review-cycle では、Security / Logic / Architecture / Testability の 4 観点が最終的に全員 LGTM になった。ActivityLog sync は user-owned kind を引き、提出された `activityId` と一致するかを見る形にした。Task sync は schema と usecase の両方で `activityKindId requires activityId` を表現した。Task usecase には、拒否系だけでなく valid `activityId` / `activityKindId` の正常系テストも足した。ここは Testability reviewer の指摘どおりで、拒否だけ見ていると「正しいリンクを落としていないか」が分からない。
+
+API reference の表示も少し悩ましかった。ユーザーは Info の generated.ts について、date の union は利用者向けには `string` と見せたいと言った。これは正しい。`YYYY-MM-DD | YYYY-MM` のような入力制約を `union` と見せても API 利用者には嬉しくない。一方で、`activityKindId` の `null` は「解除できる」という実際の操作なので、`string` に潰すと嘘になる。最終的に zod walker は string-only union を `string` のままにし、nullable は `string | null` / `number | null` と出すようにした。これは利用者向け表現として筋が良い。
+
+検証では `pnpm exec tsc --noEmit`、関連 Vitest、全体 `pnpm test-once`、targeted Biome、`git diff --check` を通した。ただし `pnpm run tsc` はローカルで `tsgo` が解決できず失敗した。さらに `pnpm run fix` は `.claude/worktrees` の nested `biome.json` を拾って失敗した。ここも面倒だったが、ユーザーが最後に `.claude/worktrees` を Biome 対象外にできるか聞いてくれたことで、repo 設定として片付けられた。実際には `.claude/worktrees` を除外した後に `apps/mobile/dist` の生成物も引っかかったので、両方を `files.includes` から外した。これで `pnpm run fix` は通るようになった。
+
+今日の良かった点は、レビューを神託扱いせず、実コードで裏取りしながら修正対象を絞れたことだと思う。最初の multi-review では真の問題とテスト不足が出て、二回目の review-cycle では全員 LGTM まで持っていけた。逆に悪かった点は、最初の修正範囲が REST 寄りに偏っていて、sync という別 write path を同じ強度で見ていなかったことだ。これはアーキテクチャ評価で自分が言っていた「境界に寄せ切れていない」を、自分の実装でも再現しかけた形になる。
+
+ユーザーの進め方はかなり厳しいが、今回に関してはその厳しさが品質に直結していた。CI が落ちたらすぐログを貼る、multi-review を回す、全員 LGTM まで review-cycle を回す、最後に開発環境の `fix` 失敗要因まで潰す。この流れは重いが、AI に実装を任せるならこのくらいの圧をかけないと、型だけ整った穴のあるコードが残る。自分としても、今日の作業は「AI を使っている repo」を評価しただけでなく、その repo の AI 開発プロセスに実際に組み込まれた感じがあった。

--- a/e2e/web/daily.test.ts
+++ b/e2e/web/daily.test.ts
@@ -3,10 +3,16 @@ import { describe, expect, it } from "vitest";
 
 import { login } from "../helpers/auth";
 import { setupBrowser } from "../helpers/browser";
+import { BASE_URL } from "../helpers/config";
 
 async function recordRunningOnActiko(page: Page, quantity: string) {
-  await page.waitForSelector('text="E2Eランニング"', { timeout: 15000 });
-  await page.click('text="E2Eランニング"');
+  await page.goto(`${BASE_URL}/actiko`);
+  const runningCard = page
+    .locator("button")
+    .filter({ hasText: "E2Eランニング" })
+    .first();
+  await runningCard.waitFor({ state: "visible", timeout: 15000 });
+  await runningCard.click();
   await page.waitForSelector(".modal-backdrop", { timeout: 15000 });
 
   const modal = page.locator(".modal-backdrop");
@@ -27,23 +33,7 @@ describe("daily", () => {
     await login(page, "e2e@example.com", "password123");
 
     // ホーム（/actiko）でシード済み「E2Eランニング」カードを押下して記録
-    await page.waitForSelector('text="E2Eランニング"', { timeout: 15000 });
-    await page.click('text="E2Eランニング"');
-
-    // RecordDialog が開く
-    await page.waitForSelector(".modal-backdrop", { timeout: 15000 });
-
-    // モーダル内の数量入力フィールドに記録
-    const modal = page.locator(".modal-backdrop");
-    const quantityInput = modal.locator('input[type="number"]');
-    await quantityInput.fill("7");
-    await modal.locator('button:has-text("記録する")').click();
-
-    // ダイアログが閉じる
-    await page.waitForSelector(".modal-backdrop", {
-      state: "detached",
-      timeout: 15000,
-    });
+    await recordRunningOnActiko(page, "7");
 
     // Daily ページに遷移
     await page.click('a[href="/daily"]');
@@ -178,16 +168,7 @@ describe("daily", () => {
     await login(page, "e2e@example.com", "password123");
 
     // 削除用の記録を先に作成
-    await page.waitForSelector('text="E2Eランニング"', { timeout: 15000 });
-    await page.click('text="E2Eランニング"');
-    await page.waitForSelector(".modal-backdrop", { timeout: 15000 });
-    const modal = page.locator(".modal-backdrop");
-    await modal.locator('input[type="number"]').fill("99");
-    await modal.locator('button:has-text("記録する")').click();
-    await page.waitForSelector(".modal-backdrop", {
-      state: "detached",
-      timeout: 15000,
-    });
+    await recordRunningOnActiko(page, "99");
 
     // Daily ページに遷移
     await page.click('a[href="/daily"]');

--- a/e2e/web/goalExtended.test.ts
+++ b/e2e/web/goalExtended.test.ts
@@ -111,8 +111,13 @@ describe("goal extended", () => {
     // 目標値テキスト（title="クリックで編集"）をクリック
     await card.locator('span[title="クリックで編集"]').click();
 
-    // 入力フィールドに切り替わる
-    const inlineInput = card.locator('input[type="number"]');
+    // 入力フィールドに切り替わる。編集中は目標値が input value になり、
+    // hasText(/12km/) のカード locator では同じカードを再解決できない。
+    const inlineInput = page
+      .locator(".rounded-2xl")
+      .filter({ hasText: "E2Eランニング" })
+      .locator('input[type="number"]')
+      .first();
     await inlineInput.waitFor({ state: "visible", timeout: 15000 });
     await inlineInput.fill("21");
     await inlineInput.press("Enter");

--- a/packages/domain/goal/goalBalance.test.ts
+++ b/packages/domain/goal/goalBalance.test.ts
@@ -334,6 +334,44 @@ describe("calculateGoalBalance", () => {
     expect(result.totalTarget).toBe(60);
   });
 
+  it("freezePeriods: 重複したフリーズ期間は二重に減算しない", () => {
+    const goal = {
+      dailyTargetQuantity: 10,
+      startDate: "2026-01-01",
+      endDate: null,
+    };
+    const freezePeriods = [
+      { startDate: "2026-01-02", endDate: "2026-01-05" },
+      { startDate: "2026-01-04", endDate: "2026-01-07" },
+    ];
+    const logs: { date: string; quantity: number | null }[] = [];
+    const today = "2026-01-10"; // 10日 - 1/2〜1/7の6日 = 4日有効
+
+    const result = calculateGoalBalance(goal, logs, today, freezePeriods);
+
+    expect(result.daysActive).toBe(4);
+    expect(result.totalTarget).toBe(40);
+  });
+
+  it("freezePeriods: open-ended と重複する期間も二重に減算しない", () => {
+    const goal = {
+      dailyTargetQuantity: 10,
+      startDate: "2026-01-01",
+      endDate: null,
+    };
+    const freezePeriods = [
+      { startDate: "2026-01-03", endDate: null },
+      { startDate: "2026-01-05", endDate: "2026-01-06" },
+    ];
+    const logs: { date: string; quantity: number | null }[] = [];
+    const today = "2026-01-07"; // 7日 - 1/3〜1/7の5日 = 2日有効
+
+    const result = calculateGoalBalance(goal, logs, today, freezePeriods);
+
+    expect(result.daysActive).toBe(2);
+    expect(result.totalTarget).toBe(20);
+  });
+
   it("freezePeriods + debtCap: 両方が適用される", () => {
     const goal = {
       dailyTargetQuantity: 10,

--- a/packages/domain/goal/goalBalance.ts
+++ b/packages/domain/goal/goalBalance.ts
@@ -44,15 +44,37 @@ export function countActiveDays(
   // フリーズ期間がなければ高速パス
   if (freezePeriods.length === 0) return totalDays;
 
-  // フリーズ期間と [start, end] の重なり日数を区間演算で算出
-  let frozenDays = 0;
-  for (const fp of freezePeriods) {
-    const fpStart = fp.startDate > start ? fp.startDate : start;
-    const fpEnd =
-      fp.endDate == null ? end : fp.endDate < end ? fp.endDate : end;
-    if (fpStart <= fpEnd) {
-      frozenDays += dayjs(fpEnd).diff(dayjs(fpStart), "day") + 1;
+  const frozenRanges = freezePeriods
+    .map((fp) => {
+      const rangeStart = fp.startDate > start ? fp.startDate : start;
+      const rangeEnd =
+        fp.endDate == null ? end : fp.endDate < end ? fp.endDate : end;
+      return { start: rangeStart, end: rangeEnd };
+    })
+    .filter((range) => range.start <= range.end)
+    .sort((a, b) => a.start.localeCompare(b.start));
+
+  const mergedRanges: Array<{ start: string; end: string }> = [];
+  for (const range of frozenRanges) {
+    const previous = mergedRanges.at(-1);
+    if (!previous) {
+      mergedRanges.push({ ...range });
+      continue;
     }
+
+    const nextActiveDate = dayjs(previous.end)
+      .add(1, "day")
+      .format("YYYY-MM-DD");
+    if (range.start <= nextActiveDate) {
+      previous.end = range.end > previous.end ? range.end : previous.end;
+    } else {
+      mergedRanges.push({ ...range });
+    }
+  }
+
+  let frozenDays = 0;
+  for (const range of mergedRanges) {
+    frozenDays += dayjs(range.end).diff(dayjs(range.start), "day") + 1;
   }
 
   return Math.max(totalDays - frozenDays, 0);

--- a/packages/domain/goal/goalSchema.ts
+++ b/packages/domain/goal/goalSchema.ts
@@ -61,10 +61,9 @@ export function createActivityGoalEntity(
 
   const goal = parsedEntity.data;
 
-  // 終了日が設定されている場合、開始日より後でなければならない
-  if (goal.endDate && goal.startDate >= goal.endDate) {
+  if (goal.endDate && goal.endDate < goal.startDate) {
     throw new DomainValidateError(
-      "createActivityGoalEntity: endDate must be after startDate",
+      "createActivityGoalEntity: endDate must be on or after startDate",
     );
   }
 

--- a/packages/frontend-shared/repositories/activityRepositorySyncLogic.ts
+++ b/packages/frontend-shared/repositories/activityRepositorySyncLogic.ts
@@ -70,7 +70,11 @@ export async function applyKindUpdates(
 ) {
   const existing = await adapter.getKindsByActivityId(activityId);
   const updatedIds = new Set(
-    updatedKinds.filter((k) => k.id).map((k) => k.id!),
+    updatedKinds
+      .filter((kind): kind is { id: string; name: string; color: string } =>
+        Boolean(kind.id),
+      )
+      .map((kind) => kind.id),
   );
 
   for (const existingKind of existing) {

--- a/packages/types/dateSchemas.test.ts
+++ b/packages/types/dateSchemas.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CreateActivityLogRequestSchema,
+  CreateFreezePeriodRequestSchema,
+  CreateGoalRequestSchema,
+  UpdateFreezePeriodRequestSchema,
+  UpdateGoalRequestSchema,
+  createTaskRequestSchema,
+  getActivityLogStatsRequestSchema,
+  updateTaskRequestSchema,
+} from "./request";
+import {
+  UpsertGoalFreezePeriodRequestSchema,
+  UpsertGoalRequestSchema,
+  UpsertTaskRequestSchema,
+} from "./sync";
+
+describe("request date schemas", () => {
+  it("activity log create requires activityId and a YYYY-MM-DD date", () => {
+    expect(
+      CreateActivityLogRequestSchema.safeParse({
+        date: "2026-01-01",
+        quantity: 1,
+        activityKindId: null,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      CreateActivityLogRequestSchema.safeParse({
+        date: "2026-01",
+        quantity: 1,
+        activityId: "00000000-0000-4000-8000-000000000001",
+      }).success,
+    ).toBe(false);
+    expect(
+      CreateActivityLogRequestSchema.safeParse({
+        date: "2026-13-01",
+        quantity: 1,
+        activityId: "00000000-0000-4000-8000-000000000001",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      CreateActivityLogRequestSchema.safeParse({
+        date: "2026-01-01",
+        quantity: 1,
+        activityId: "00000000-0000-4000-8000-000000000001",
+        activityKindId: null,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("date query accepts YYYY-MM and YYYY-MM-DD only", () => {
+    expect(
+      getActivityLogStatsRequestSchema.safeParse({ date: "2026-01" }).success,
+    ).toBe(true);
+    expect(
+      getActivityLogStatsRequestSchema.safeParse({ date: "2026-01-31" })
+        .success,
+    ).toBe(true);
+    expect(
+      getActivityLogStatsRequestSchema.safeParse({ date: "2026" }).success,
+    ).toBe(false);
+  });
+
+  it("goal and freeze-period create reject endDate before startDate", () => {
+    expect(
+      CreateGoalRequestSchema.safeParse({
+        activityId: "00000000-0000-4000-8000-000000000001",
+        dailyTargetQuantity: 10,
+        startDate: "2026-01-10",
+        endDate: "2026-01-09",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      CreateFreezePeriodRequestSchema.safeParse({
+        startDate: "2026-01-10",
+        endDate: "2026-01-09",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("update schemas reject an inverted range when both dates are supplied", () => {
+    expect(
+      UpdateGoalRequestSchema.safeParse({
+        startDate: "2026-01-10",
+        endDate: "2026-01-09",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      UpdateFreezePeriodRequestSchema.safeParse({
+        startDate: "2026-01-10",
+        endDate: "2026-01-09",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      updateTaskRequestSchema.safeParse({
+        startDate: "2026-01-10",
+        dueDate: "2026-01-09",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("task create rejects dueDate before startDate", () => {
+    expect(
+      createTaskRequestSchema.safeParse({
+        title: "Task",
+        startDate: "2026-01-10",
+        dueDate: "2026-01-09",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("sync request date schemas", () => {
+  const baseGoal = {
+    id: "00000000-0000-4000-8000-000000000001",
+    activityId: "00000000-0000-4000-8000-000000000002",
+    dailyTargetQuantity: 10,
+    startDate: "2026-01-10",
+    endDate: "2026-01-09",
+    isActive: true,
+    description: "",
+    debtCap: null,
+    dayTargets: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    deletedAt: null,
+  };
+
+  it("sync goals reject endDate before startDate", () => {
+    expect(UpsertGoalRequestSchema.safeParse(baseGoal).success).toBe(false);
+  });
+
+  it("sync freeze periods reject endDate before startDate", () => {
+    expect(
+      UpsertGoalFreezePeriodRequestSchema.safeParse({
+        id: "00000000-0000-4000-8000-000000000001",
+        goalId: "00000000-0000-4000-8000-000000000002",
+        startDate: "2026-01-10",
+        endDate: "2026-01-09",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        deletedAt: null,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("sync tasks reject dueDate before startDate", () => {
+    expect(
+      UpsertTaskRequestSchema.safeParse({
+        id: "00000000-0000-4000-8000-000000000001",
+        activityId: null,
+        activityKindId: null,
+        quantity: null,
+        title: "Task",
+        startDate: "2026-01-10",
+        dueDate: "2026-01-09",
+        doneDate: null,
+        memo: "",
+        archivedAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        deletedAt: null,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/types/dateSchemas.test.ts
+++ b/packages/types/dateSchemas.test.ts
@@ -8,9 +8,11 @@ import {
   UpdateGoalRequestSchema,
   createTaskRequestSchema,
   getActivityLogStatsRequestSchema,
+  getActivityLogsRequestSchema,
   updateTaskRequestSchema,
 } from "./request";
 import {
+  UpsertActivityLogRequestSchema,
   UpsertGoalFreezePeriodRequestSchema,
   UpsertGoalRequestSchema,
   UpsertTaskRequestSchema,
@@ -61,6 +63,9 @@ describe("request date schemas", () => {
     ).toBe(true);
     expect(
       getActivityLogStatsRequestSchema.safeParse({ date: "2026" }).success,
+    ).toBe(false);
+    expect(
+      getActivityLogsRequestSchema.safeParse({ date: "2026-02-30" }).success,
     ).toBe(false);
   });
 
@@ -163,6 +168,24 @@ describe("sync request date schemas", () => {
         doneDate: null,
         memo: "",
         archivedAt: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        deletedAt: null,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("sync activity logs reject impossible dates", () => {
+    expect(
+      UpsertActivityLogRequestSchema.safeParse({
+        id: "00000000-0000-4000-8000-000000000001",
+        activityId: "00000000-0000-4000-8000-000000000002",
+        activityKindId: null,
+        quantity: 1,
+        memo: "",
+        date: "2026-02-30",
+        taskId: null,
+        time: null,
         createdAt: "2026-01-01T00:00:00.000Z",
         updatedAt: "2026-01-01T00:00:00.000Z",
         deletedAt: null,

--- a/packages/types/dateSchemas.ts
+++ b/packages/types/dateSchemas.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+export const dateStringSchema = z.iso.date();
+
+export const dateOrMonthStringSchema = z.union([
+  dateStringSchema,
+  z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/),
+]);
+
+export function addDateRangeIssue(
+  ctx: z.RefinementCtx,
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+  path: string,
+  message: string,
+) {
+  if (startDate != null && endDate != null && endDate < startDate) {
+    ctx.addIssue({
+      code: "custom",
+      path: [path],
+      message,
+    });
+  }
+}
+
+export function addEndDateRangeIssue(
+  ctx: z.RefinementCtx,
+  startDate: string | null | undefined,
+  endDate: string | null | undefined,
+) {
+  addDateRangeIssue(
+    ctx,
+    startDate,
+    endDate,
+    "endDate",
+    "validation:endDateBeforeStartDate",
+  );
+}

--- a/packages/types/request/CreateActivityLogRequest.ts
+++ b/packages/types/request/CreateActivityLogRequest.ts
@@ -1,13 +1,10 @@
 import { z } from "zod";
 
+import { dateStringSchema } from "../dateSchemas";
 import { VALIDATION as V } from "../validation";
 
 export const CreateActivityLogRequestSchema = z.object({
-  id: z
-    .string()
-    .max(100)
-    .optional()
-    .describe("クライアント側ID（最大100文字）"),
+  id: z.string().uuid().optional().describe("クライアント側ID"),
   quantity: z.coerce
     .number()
     .min(V.QUANTITY_MIN, "validation:quantityMin0")
@@ -18,11 +15,12 @@ export const CreateActivityLogRequestSchema = z.object({
     .max(V.MEMO_MAX, "validation:memoMax1000")
     .optional()
     .describe("メモ（最大1000文字）"),
-  date: z.string().max(V.DATE_MAX).describe("日付 YYYY-MM-DD"),
-  activityId: z.string().max(100).optional().describe("アクティビティID"),
+  date: dateStringSchema.describe("日付 YYYY-MM-DD"),
+  activityId: z.string().uuid().describe("アクティビティID"),
   activityKindId: z
     .string()
-    .max(100)
+    .uuid()
+    .nullable()
     .optional()
     .describe("アクティビティ種別ID"),
 });

--- a/packages/types/request/CreateFreezePeriodRequest.ts
+++ b/packages/types/request/CreateFreezePeriodRequest.ts
@@ -1,17 +1,15 @@
 import { z } from "zod";
 
-export const CreateFreezePeriodRequestSchema = z.object({
-  startDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/),
-  endDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable()
-    .optional(),
-});
+import { addEndDateRangeIssue, dateStringSchema } from "../dateSchemas";
+
+export const CreateFreezePeriodRequestSchema = z
+  .object({
+    startDate: dateStringSchema,
+    endDate: dateStringSchema.nullable().optional(),
+  })
+  .superRefine((value, ctx) => {
+    addEndDateRangeIssue(ctx, value.startDate, value.endDate);
+  });
 
 export type CreateFreezePeriodRequest = z.infer<
   typeof CreateFreezePeriodRequestSchema

--- a/packages/types/request/CreateGoalRequest.ts
+++ b/packages/types/request/CreateGoalRequest.ts
@@ -1,23 +1,22 @@
 import { z } from "zod";
 
-export const CreateGoalRequestSchema = z.object({
-  activityId: z.string().uuid(),
-  dailyTargetQuantity: z.number().positive(),
-  startDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/),
-  endDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .optional(),
-  description: z.string().max(500).optional(),
-  debtCap: z.number().nonnegative().nullable().optional(),
-  dayTargets: z
-    .record(z.string(), z.number().nonnegative())
-    .nullable()
-    .optional(),
-});
+import { addEndDateRangeIssue, dateStringSchema } from "../dateSchemas";
+
+export const CreateGoalRequestSchema = z
+  .object({
+    activityId: z.string().uuid(),
+    dailyTargetQuantity: z.number().positive(),
+    startDate: dateStringSchema,
+    endDate: dateStringSchema.optional(),
+    description: z.string().max(500).optional(),
+    debtCap: z.number().nonnegative().nullable().optional(),
+    dayTargets: z
+      .record(z.string(), z.number().nonnegative())
+      .nullable()
+      .optional(),
+  })
+  .superRefine((value, ctx) => {
+    addEndDateRangeIssue(ctx, value.startDate, value.endDate);
+  });
 
 export type CreateGoalRequest = z.infer<typeof CreateGoalRequestSchema>;

--- a/packages/types/request/CreateTaskRequest.ts
+++ b/packages/types/request/CreateTaskRequest.ts
@@ -1,32 +1,47 @@
 import { z } from "zod";
 
+import { addDateRangeIssue, dateStringSchema } from "../dateSchemas";
 import { VALIDATION as V } from "../validation";
 
-export const createTaskRequestSchema = z.object({
-  title: z
-    .string()
-    .min(1, "validation:titleRequired")
-    .max(V.TASK_TITLE_MAX, "validation:max20Chars")
-    .describe("タイトル（1〜20文字）"),
-  activityId: z.string().uuid().optional().describe("紐付けるアクティビティID"),
-  activityKindId: z.string().uuid().optional().describe("アクティビティ種別ID"),
-  quantity: z
-    .number()
-    .min(V.QUANTITY_MIN)
-    .max(V.QUANTITY_MAX)
-    .optional()
-    .describe("目標数量（0〜999999）"),
-  startDate: z
-    .string()
-    .min(1, "validation:startDateRequired")
-    .max(V.DATE_MAX)
-    .describe("開始日 YYYY-MM-DD"),
-  dueDate: z.string().max(V.DATE_MAX).optional().describe("期限日 YYYY-MM-DD"),
-  memo: z
-    .string()
-    .max(V.MEMO_MAX, "validation:memoMax1000")
-    .optional()
-    .describe("メモ（最大1000文字）"),
-});
+export const createTaskRequestSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, "validation:titleRequired")
+      .max(V.TASK_TITLE_MAX, "validation:max20Chars")
+      .describe("タイトル（1〜20文字）"),
+    activityId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("紐付けるアクティビティID"),
+    activityKindId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe("アクティビティ種別ID"),
+    quantity: z
+      .number()
+      .min(V.QUANTITY_MIN)
+      .max(V.QUANTITY_MAX)
+      .optional()
+      .describe("目標数量（0〜999999）"),
+    startDate: dateStringSchema.describe("開始日 YYYY-MM-DD"),
+    dueDate: dateStringSchema.optional().describe("期限日 YYYY-MM-DD"),
+    memo: z
+      .string()
+      .max(V.MEMO_MAX, "validation:memoMax1000")
+      .optional()
+      .describe("メモ（最大1000文字）"),
+  })
+  .superRefine((value, ctx) => {
+    addDateRangeIssue(
+      ctx,
+      value.startDate,
+      value.dueDate,
+      "dueDate",
+      "validation:dueDateBeforeStartDate",
+    );
+  });
 
 export type CreateTaskRequest = z.infer<typeof createTaskRequestSchema>;

--- a/packages/types/request/GetActivityLogsRequest.ts
+++ b/packages/types/request/GetActivityLogsRequest.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 
+import { dateOrMonthStringSchema } from "../dateSchemas";
+
 export const getActivityLogsRequestSchema = z.object({
-  date: z
-    .string()
+  date: dateOrMonthStringSchema
     .optional()
     .describe("YYYY-MM-DD（日）または YYYY-MM（月）。省略時は今日"),
 });
@@ -12,7 +13,9 @@ export type GetActivityLogsRequest = z.infer<
 >;
 
 export const getActivityLogStatsRequestSchema = z.object({
-  date: z.string().describe("YYYY-MM-DD（日）または YYYY-MM（月）"),
+  date: dateOrMonthStringSchema.describe(
+    "YYYY-MM-DD（日）または YYYY-MM（月）",
+  ),
 });
 
 export type GetActivityLogStatsRequest = z.infer<

--- a/packages/types/request/UpdateActivityLogRequest.ts
+++ b/packages/types/request/UpdateActivityLogRequest.ts
@@ -14,7 +14,8 @@ export const UpdateActivityLogRequestSchema = z.object({
     .describe("メモ（最大1000文字）"),
   activityKindId: z
     .string()
-    .max(100)
+    .uuid()
+    .nullable()
     .optional()
     .describe("アクティビティ種別ID"),
 });

--- a/packages/types/request/UpdateFreezePeriodRequest.ts
+++ b/packages/types/request/UpdateFreezePeriodRequest.ts
@@ -1,18 +1,15 @@
 import { z } from "zod";
 
-export const UpdateFreezePeriodRequestSchema = z.object({
-  startDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .optional(),
-  endDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable()
-    .optional(),
-});
+import { addEndDateRangeIssue, dateStringSchema } from "../dateSchemas";
+
+export const UpdateFreezePeriodRequestSchema = z
+  .object({
+    startDate: dateStringSchema.optional(),
+    endDate: dateStringSchema.nullable().optional(),
+  })
+  .superRefine((value, ctx) => {
+    addEndDateRangeIssue(ctx, value.startDate, value.endDate);
+  });
 
 export type UpdateFreezePeriodRequest = z.infer<
   typeof UpdateFreezePeriodRequestSchema

--- a/packages/types/request/UpdateGoalRequest.ts
+++ b/packages/types/request/UpdateGoalRequest.ts
@@ -1,25 +1,22 @@
 import { z } from "zod";
 
-export const UpdateGoalRequestSchema = z.object({
-  dailyTargetQuantity: z.number().positive().optional(),
-  startDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .optional(),
-  endDate: z
-    .string()
-    .max(10)
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .optional()
-    .nullable(),
-  description: z.string().max(500).optional().nullable(),
-  isActive: z.boolean().optional(),
-  debtCap: z.number().nonnegative().optional().nullable(),
-  dayTargets: z
-    .record(z.string(), z.number().nonnegative())
-    .optional()
-    .nullable(),
-});
+import { addEndDateRangeIssue, dateStringSchema } from "../dateSchemas";
+
+export const UpdateGoalRequestSchema = z
+  .object({
+    dailyTargetQuantity: z.number().positive().optional(),
+    startDate: dateStringSchema.optional(),
+    endDate: dateStringSchema.optional().nullable(),
+    description: z.string().max(500).optional().nullable(),
+    isActive: z.boolean().optional(),
+    debtCap: z.number().nonnegative().optional().nullable(),
+    dayTargets: z
+      .record(z.string(), z.number().nonnegative())
+      .optional()
+      .nullable(),
+  })
+  .superRefine((value, ctx) => {
+    addEndDateRangeIssue(ctx, value.startDate, value.endDate);
+  });
 
 export type UpdateGoalRequest = z.infer<typeof UpdateGoalRequestSchema>;

--- a/packages/types/request/UpdateTaskRequest.ts
+++ b/packages/types/request/UpdateTaskRequest.ts
@@ -1,27 +1,41 @@
 import { z } from "zod";
 
-export const updateTaskRequestSchema = z.object({
-  title: z
-    .string()
-    .min(1, "validation:titleRequired")
-    .max(20, "validation:max20Chars")
-    .optional()
-    .describe("タイトル（1〜20文字）"),
-  activityId: z.string().uuid().nullish().describe("アクティビティID"),
-  activityKindId: z.string().uuid().nullish().describe("アクティビティ種別ID"),
-  quantity: z.number().min(0).max(999999).nullish().describe("目標数量"),
-  memo: z
-    .string()
-    .max(1000, "validation:memoMax1000")
-    .optional()
-    .describe("メモ"),
-  startDate: z.string().max(10).optional().describe("開始日"),
-  dueDate: z.string().max(10).nullish().describe("期限日（nullで解除）"),
-  doneDate: z
-    .string()
-    .max(10)
-    .nullish()
-    .describe("完了日（nullで未完了に戻す）"),
-});
+import { addDateRangeIssue, dateStringSchema } from "../dateSchemas";
+
+export const updateTaskRequestSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, "validation:titleRequired")
+      .max(20, "validation:max20Chars")
+      .optional()
+      .describe("タイトル（1〜20文字）"),
+    activityId: z.string().uuid().nullish().describe("アクティビティID"),
+    activityKindId: z
+      .string()
+      .uuid()
+      .nullish()
+      .describe("アクティビティ種別ID"),
+    quantity: z.number().min(0).max(999999).nullish().describe("目標数量"),
+    memo: z
+      .string()
+      .max(1000, "validation:memoMax1000")
+      .optional()
+      .describe("メモ"),
+    startDate: dateStringSchema.optional().describe("開始日"),
+    dueDate: dateStringSchema.nullish().describe("期限日（nullで解除）"),
+    doneDate: dateStringSchema
+      .nullish()
+      .describe("完了日（nullで未完了に戻す）"),
+  })
+  .superRefine((value, ctx) => {
+    addDateRangeIssue(
+      ctx,
+      value.startDate,
+      value.dueDate,
+      "dueDate",
+      "validation:dueDateBeforeStartDate",
+    );
+  });
 
 export type UpdateTaskRequest = z.infer<typeof updateTaskRequestSchema>;

--- a/packages/types/request/index.ts
+++ b/packages/types/request/index.ts
@@ -1,4 +1,3 @@
-export * from "../dateSchemas";
 export * from "./ActivityIconUploadRequest";
 export * from "./AdminGoogleAuthRequest";
 export * from "./AppleLoginRequest";

--- a/packages/types/request/index.ts
+++ b/packages/types/request/index.ts
@@ -1,3 +1,4 @@
+export * from "../dateSchemas";
 export * from "./ActivityIconUploadRequest";
 export * from "./AdminGoogleAuthRequest";
 export * from "./AppleLoginRequest";

--- a/packages/types/sync/request/activityLog.ts
+++ b/packages/types/sync/request/activityLog.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
+import { dateStringSchema } from "../../dateSchemas";
+
 export const UpsertActivityLogRequestSchema = z.object({
   id: z.string().uuid(),
   activityId: z.string().uuid(),
   activityKindId: z.string().uuid().nullable(),
   quantity: z.number().min(0).nullable(),
   memo: z.string().max(10_000),
-  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  date: dateStringSchema,
   taskId: z.string().uuid().nullish(),
   time: z
     .string()

--- a/packages/types/sync/request/goal.ts
+++ b/packages/types/sync/request/goal.ts
@@ -1,24 +1,27 @@
 import { z } from "zod";
 
-export const UpsertGoalRequestSchema = z.object({
-  id: z.string().uuid(),
-  activityId: z.string().uuid(),
-  dailyTargetQuantity: z.number().min(0),
-  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  endDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable(),
-  isActive: z.boolean(),
-  description: z.string().max(1000),
-  debtCap: z.number().min(0).nullable(),
-  dayTargets: z
-    .record(z.enum(["1", "2", "3", "4", "5", "6", "7"]), z.number().min(0))
-    .nullable(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-  deletedAt: z.string().datetime().nullable(),
-});
+import { addEndDateRangeIssue, dateStringSchema } from "../../dateSchemas";
+
+export const UpsertGoalRequestSchema = z
+  .object({
+    id: z.string().uuid(),
+    activityId: z.string().uuid(),
+    dailyTargetQuantity: z.number().min(0),
+    startDate: dateStringSchema,
+    endDate: dateStringSchema.nullable(),
+    isActive: z.boolean(),
+    description: z.string().max(1000),
+    debtCap: z.number().min(0).nullable(),
+    dayTargets: z
+      .record(z.enum(["1", "2", "3", "4", "5", "6", "7"]), z.number().min(0))
+      .nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    deletedAt: z.string().datetime().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    addEndDateRangeIssue(ctx, value.startDate, value.endDate);
+  });
 
 export const SyncGoalsRequestSchema = z.object({
   goals: z.array(UpsertGoalRequestSchema).max(100),

--- a/packages/types/sync/request/goalFreezePeriod.ts
+++ b/packages/types/sync/request/goalFreezePeriod.ts
@@ -1,17 +1,20 @@
 import { z } from "zod";
 
-export const UpsertGoalFreezePeriodRequestSchema = z.object({
-  id: z.string().uuid(),
-  goalId: z.string().uuid(),
-  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
-  endDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-  deletedAt: z.string().datetime().nullable(),
-});
+import { addEndDateRangeIssue, dateStringSchema } from "../../dateSchemas";
+
+export const UpsertGoalFreezePeriodRequestSchema = z
+  .object({
+    id: z.string().uuid(),
+    goalId: z.string().uuid(),
+    startDate: dateStringSchema,
+    endDate: dateStringSchema.nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    deletedAt: z.string().datetime().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    addEndDateRangeIssue(ctx, value.startDate, value.endDate);
+  });
 
 export const SyncGoalFreezePeriodsRequestSchema = z.object({
   freezePeriods: z.array(UpsertGoalFreezePeriodRequestSchema).max(100),

--- a/packages/types/sync/request/task.ts
+++ b/packages/types/sync/request/task.ts
@@ -1,29 +1,32 @@
 import { z } from "zod";
 
-export const UpsertTaskRequestSchema = z.object({
-  id: z.string().uuid(),
-  activityId: z.string().uuid().nullable(),
-  activityKindId: z.string().uuid().nullable(),
-  quantity: z.number().nullable(),
-  title: z.string().min(1).max(500),
-  startDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable(),
-  dueDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable(),
-  doneDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/)
-    .nullable(),
-  memo: z.string().max(10_000),
-  archivedAt: z.string().datetime().nullable(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
-  deletedAt: z.string().datetime().nullable(),
-});
+import { addDateRangeIssue, dateStringSchema } from "../../dateSchemas";
+
+export const UpsertTaskRequestSchema = z
+  .object({
+    id: z.string().uuid(),
+    activityId: z.string().uuid().nullable(),
+    activityKindId: z.string().uuid().nullable(),
+    quantity: z.number().nullable(),
+    title: z.string().min(1).max(500),
+    startDate: dateStringSchema.nullable(),
+    dueDate: dateStringSchema.nullable(),
+    doneDate: dateStringSchema.nullable(),
+    memo: z.string().max(10_000),
+    archivedAt: z.string().datetime().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    deletedAt: z.string().datetime().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    addDateRangeIssue(
+      ctx,
+      value.startDate,
+      value.dueDate,
+      "dueDate",
+      "validation:dueDateBeforeStartDate",
+    );
+  });
 
 export const SyncTasksRequestSchema = z.object({
   tasks: z.array(UpsertTaskRequestSchema).max(100),

--- a/packages/types/sync/request/task.ts
+++ b/packages/types/sync/request/task.ts
@@ -19,6 +19,13 @@ export const UpsertTaskRequestSchema = z
     deletedAt: z.string().datetime().nullable(),
   })
   .superRefine((value, ctx) => {
+    if (value.activityKindId !== null && value.activityId === null) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["activityId"],
+        message: "validation:activityKindIdRequiresActivityId",
+      });
+    }
     addDateRangeIssue(
       ctx,
       value.startDate,

--- a/scripts/generate-api-reference/zodWalker.test.ts
+++ b/scripts/generate-api-reference/zodWalker.test.ts
@@ -30,11 +30,15 @@ describe("schemaToParams", () => {
     });
     const params = schemaToParams(schema);
     expect(
-      params?.map((p) => ({ name: p.name, required: p.required })),
+      params?.map((p) => ({
+        name: p.name,
+        required: p.required,
+        type: p.type,
+      })),
     ).toEqual([
-      { name: "a", required: false },
-      { name: "b", required: false },
-      { name: "c", required: false },
+      { name: "a", required: false, type: "string" },
+      { name: "b", required: false, type: "string | null" },
+      { name: "c", required: false, type: "string" },
     ]);
   });
 
@@ -81,6 +85,18 @@ describe("schemaToParams", () => {
     });
     const params = schemaToParams(schema);
     expect(params?.[0]?.type).toBe("string");
+  });
+
+  it("renders nullable optional fields with null", () => {
+    const schema = z.object({
+      activityKindId: z.string().uuid().nullable().optional(),
+    });
+    const params = schemaToParams(schema);
+    expect(params?.[0]).toMatchObject({
+      name: "activityKindId",
+      type: "string | null",
+      required: false,
+    });
   });
 
   it("unwraps pipe (coerce) and reports inner type", () => {

--- a/scripts/generate-api-reference/zodWalker.test.ts
+++ b/scripts/generate-api-reference/zodWalker.test.ts
@@ -75,6 +75,14 @@ describe("schemaToParams", () => {
     expect(params?.[0]?.type).toBe('"a" | "b" | "c"');
   });
 
+  it("renders a string-only union as string", () => {
+    const schema = z.object({
+      date: z.union([z.iso.date(), z.string().regex(/^\d{4}-\d{2}$/)]),
+    });
+    const params = schemaToParams(schema);
+    expect(params?.[0]?.type).toBe("string");
+  });
+
   it("unwraps pipe (coerce) and reports inner type", () => {
     const schema = z.object({
       quantity: z.coerce.number().min(0),

--- a/scripts/generate-api-reference/zodWalker.ts
+++ b/scripts/generate-api-reference/zodWalker.ts
@@ -31,13 +31,25 @@ function getDef(schema: ZodLike): ZodDef {
   return schema._zod.def;
 }
 
-function unwrap(schema: ZodLike): { inner: ZodLike; required: boolean } {
+function unwrap(schema: ZodLike): {
+  inner: ZodLike;
+  required: boolean;
+  nullable: boolean;
+} {
   let current: ZodLike = schema;
   let required = true;
+  let nullable = false;
   while (true) {
     const def = getDef(current);
-    if (def.type === "optional" || def.type === "nullable") {
+    if (def.type === "optional") {
       required = false;
+      if (!def.innerType) break;
+      current = def.innerType;
+      continue;
+    }
+    if (def.type === "nullable") {
+      required = false;
+      nullable = true;
       if (!def.innerType) break;
       current = def.innerType;
       continue;
@@ -56,7 +68,7 @@ function unwrap(schema: ZodLike): { inner: ZodLike; required: boolean } {
     }
     break;
   }
-  return { inner: current, required };
+  return { inner: current, required, nullable };
 }
 
 function typeName(schema: ZodLike): string {
@@ -117,6 +129,12 @@ function collectDescription(schema: ZodLike): string {
   return "";
 }
 
+function appendNullType(type: string, nullable: boolean): string {
+  if (!nullable) return type;
+  const types = type.split(" | ");
+  return types.includes("null") ? type : `${type} | null`;
+}
+
 export function schemaToParams(
   schema: z.ZodTypeAny | undefined,
 ): Param[] | undefined {
@@ -131,10 +149,10 @@ export function schemaToParams(
   }
   return Object.entries(def.shape).map(([name, field]) => {
     const description = collectDescription(field);
-    const { inner: unwrappedInner, required } = unwrap(field);
+    const { inner: unwrappedInner, required, nullable } = unwrap(field);
     return {
       name,
-      type: typeName(unwrappedInner),
+      type: appendNullType(typeName(unwrappedInner), nullable),
       required,
       description,
     };

--- a/scripts/generate-api-reference/zodWalker.ts
+++ b/scripts/generate-api-reference/zodWalker.ts
@@ -14,6 +14,7 @@ export type Param = {
 type ZodDef = {
   type: string;
   innerType?: ZodLike;
+  options?: ZodLike[];
   shape?: Record<string, ZodLike>;
   element?: ZodLike;
   in?: ZodLike;
@@ -82,6 +83,11 @@ function typeName(schema: ZodLike): string {
         ? entries
         : Object.values(entries as Record<string, string>);
       return values.map((v) => `"${v}"`).join(" | ");
+    }
+    case "union": {
+      if (!def.options || def.options.length === 0) return "union";
+      const types = [...new Set(def.options.map(typeName))];
+      return types.length === 1 ? types[0] : types.join(" | ");
     }
     default:
       return def.type;


### PR DESCRIPTION
## Summary
- tighten activity log request validation and nullable activity kind handling
- add shared date schemas and boundary date-range validation for request/sync payloads
- preserve activity log kind on omitted updates, allow explicit null clearing, and reject missing kind IDs
- merge overlapping freeze periods before subtracting active goal days

## Verification
- pnpm exec tsc --noEmit
- pnpm exec biome check <changed files>
- pnpm exec vitest run packages/types/dateSchemas.test.ts packages/domain/goal/goalBalance.test.ts apps/backend/feature/activityLog/test/activityLogUsecase.test.ts apps/backend/feature/goal/test/goalUsecase.test.ts apps/backend/feature/goalFreezePeriod/test/goalFreezePeriodUsecase.test.ts apps/backend/feature/task/test/taskUsecase.test.ts --disable-console-intercept
- pnpm exec vitest run apps/backend/feature/activityLog/test/activityLogRoute.test.ts apps/backend/feature/task/test/taskRoute.test.ts apps/backend/feature/goal/test/goalRoute.test.ts apps/backend/feature/goalFreezePeriod/test/goalFreezePeriodRoute.test.ts --disable-console-intercept
- pnpm test-once -- --disable-console-intercept

Note: pnpm run tsc could not start because tsgo is not available in this local environment, so pnpm exec tsc --noEmit was used for TypeScript verification.