### PR TITLE
Tighten goal day targets and activity log time schemas

### DIFF
--- a/packages/types/dateSchemas.test.ts
+++ b/packages/types/dateSchemas.test.ts
@@ -87,6 +87,39 @@ describe("request date schemas", () => {
     ).toBe(false);
   });
 
+  it("goal create and update restrict dayTargets to ISO weekday keys", () => {
+    expect(
+      CreateGoalRequestSchema.safeParse({
+        activityId: "00000000-0000-4000-8000-000000000001",
+        dailyTargetQuantity: 10,
+        startDate: "2026-01-01",
+        dayTargets: {
+          "1": 5,
+          "7": 0,
+        },
+      }).success,
+    ).toBe(true);
+
+    expect(
+      CreateGoalRequestSchema.safeParse({
+        activityId: "00000000-0000-4000-8000-000000000001",
+        dailyTargetQuantity: 10,
+        startDate: "2026-01-01",
+        dayTargets: {
+          "8": 5,
+        },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      UpdateGoalRequestSchema.safeParse({
+        dayTargets: {
+          foo: 5,
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   it("update schemas reject an inverted range when both dates are supplied", () => {
     expect(
       UpdateGoalRequestSchema.safeParse({
@@ -191,5 +224,38 @@ describe("sync request date schemas", () => {
         deletedAt: null,
       }).success,
     ).toBe(false);
+  });
+
+  it("sync activity logs validate HH:mm(:ss) time ranges", () => {
+    const baseLog = {
+      id: "00000000-0000-4000-8000-000000000001",
+      activityId: "00000000-0000-4000-8000-000000000002",
+      activityKindId: null,
+      quantity: 1,
+      memo: "",
+      date: "2026-01-01",
+      taskId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      deletedAt: null,
+    };
+
+    for (const time of [null, "00:00", "23:59", "23:59:59"]) {
+      expect(
+        UpsertActivityLogRequestSchema.safeParse({
+          ...baseLog,
+          time,
+        }).success,
+      ).toBe(true);
+    }
+
+    for (const time of ["24:00", "12:60", "12:30:60", "99:99:99"]) {
+      expect(
+        UpsertActivityLogRequestSchema.safeParse({
+          ...baseLog,
+          time,
+        }).success,
+      ).toBe(false);
+    }
   });
 });

--- a/packages/types/dayTargetsSchema.ts
+++ b/packages/types/dayTargetsSchema.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const dayTargetsRequestSchema = z.partialRecord(
+  z.enum(["1", "2", "3", "4", "5", "6", "7"]),
+  z.number().nonnegative(),
+);

--- a/packages/types/request/CreateGoalRequest.ts
+++ b/packages/types/request/CreateGoalRequest.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { addEndDateRangeIssue, dateStringSchema } from "../dateSchemas";
+import { dayTargetsRequestSchema } from "../dayTargetsSchema";
 
 export const CreateGoalRequestSchema = z
   .object({
@@ -10,10 +11,7 @@ export const CreateGoalRequestSchema = z
     endDate: dateStringSchema.optional(),
     description: z.string().max(500).optional(),
     debtCap: z.number().nonnegative().nullable().optional(),
-    dayTargets: z
-      .record(z.string(), z.number().nonnegative())
-      .nullable()
-      .optional(),
+    dayTargets: dayTargetsRequestSchema.nullable().optional(),
   })
   .superRefine((value, ctx) => {
     addEndDateRangeIssue(ctx, value.startDate, value.endDate);

--- a/packages/types/request/UpdateGoalRequest.ts
+++ b/packages/types/request/UpdateGoalRequest.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { addEndDateRangeIssue, dateStringSchema } from "../dateSchemas";
+import { dayTargetsRequestSchema } from "../dayTargetsSchema";
 
 export const UpdateGoalRequestSchema = z
   .object({
@@ -10,10 +11,7 @@ export const UpdateGoalRequestSchema = z
     description: z.string().max(500).optional().nullable(),
     isActive: z.boolean().optional(),
     debtCap: z.number().nonnegative().optional().nullable(),
-    dayTargets: z
-      .record(z.string(), z.number().nonnegative())
-      .optional()
-      .nullable(),
+    dayTargets: dayTargetsRequestSchema.optional().nullable(),
   })
   .superRefine((value, ctx) => {
     addEndDateRangeIssue(ctx, value.startDate, value.endDate);

--- a/packages/types/sync/request/activityLog.ts
+++ b/packages/types/sync/request/activityLog.ts
@@ -12,7 +12,7 @@ export const UpsertActivityLogRequestSchema = z.object({
   taskId: z.string().uuid().nullish(),
   time: z
     .string()
-    .regex(/^\d{2}:\d{2}(:\d{2})?$/)
+    .regex(/^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/)
     .nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),


### PR DESCRIPTION
## Summary
- Restrict goal create/update `dayTargets` keys to ISO weekdays `1` through `7` with a shared Zod schema.
- Tighten sync activity log `time` validation to valid `HH:mm(:ss)` ranges.
- Add boundary tests for valid and invalid weekday keys and time values.

## Tests
- `pnpm exec biome check packages/types/dayTargetsSchema.ts packages/types/request/CreateGoalRequest.ts packages/types/request/UpdateGoalRequest.ts packages/types/sync/request/activityLog.ts packages/types/dateSchemas.test.ts --write`
- `pnpm exec vitest run packages/types/dateSchemas.test.ts --disable-console-intercept`
- `pnpm exec tsc --noEmit`
- `pnpm test-once -- --disable-console-intercept`
- `pnpm run tsc`