### PR TITLE
Improve note markdown editor input

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -3,7 +3,7 @@ import type { Page } from "playwright";
 import { BASE_URL } from "./config";
 
 export async function login(page: Page, loginId: string, password: string) {
-  await page.goto(BASE_URL);
+  await page.goto(BASE_URL, { timeout: 60000, waitUntil: "domcontentloaded" });
   await page.locator("#loginId").waitFor({ state: "visible", timeout: 15000 });
   await page.fill("#loginId", loginId);
   await page.fill("#password", password);

--- a/e2e/helpers/note.ts
+++ b/e2e/helpers/note.ts
@@ -1,0 +1,75 @@
+import type { Locator, Page } from "playwright";
+
+export async function openNotes(page: Page) {
+  await page.click('button[aria-label="Menu"]');
+  await page.click('a:has-text("Notes")');
+  await page.waitForURL("**/notes", { timeout: 15000 });
+}
+
+export async function openNewNote(page: Page) {
+  await openNotes(page);
+  await page.click('button[aria-label="ノートを作成"]');
+  await page.waitForURL("**/notes/new", { timeout: 15000 });
+  await page
+    .locator('input[placeholder="ノートのタイトル"]')
+    .waitFor({ state: "visible", timeout: 15000 });
+}
+
+export function getNoteEditor(page: Page) {
+  return page.frameLocator('iframe[title="内容"]').locator("#editor");
+}
+
+export async function setNoteEditorHtml(
+  editor: Locator,
+  html: string,
+  selector = "p",
+) {
+  await editor.evaluate(
+    (element, { html, selector }) => {
+      element.innerHTML = html;
+      const target = element.querySelector(selector) || element;
+      const textNode =
+        target.firstChild && target.firstChild.nodeType === Node.TEXT_NODE
+          ? target.firstChild
+          : target;
+      const range = document.createRange();
+      range.setStart(textNode, textNode.textContent?.length || 0);
+      range.collapse(true);
+
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      element.focus();
+      element.dispatchEvent(
+        new InputEvent("input", {
+          bubbles: true,
+          data: "",
+          inputType: "insertText",
+        }),
+      );
+    },
+    { html, selector },
+  );
+}
+
+export async function pasteMarkdownIntoNoteEditor(
+  editor: Locator,
+  markdown: string,
+) {
+  await editor.evaluate((element, markdown) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData("text/plain", markdown);
+
+    element.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dataTransfer,
+      }),
+    );
+  }, markdown);
+}
+
+export async function saveNote(page: Page) {
+  await page.click('button:has-text("保存")');
+}

--- a/e2e/web/noteEditor.test.ts
+++ b/e2e/web/noteEditor.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { login } from "../helpers/auth";
+import { setupBrowser } from "../helpers/browser";
+import {
+  getNoteEditor,
+  openNewNote,
+  pasteMarkdownIntoNoteEditor,
+  setNoteEditorHtml,
+} from "../helpers/note";
+
+function isOutsideInline(
+  html: string,
+  tag: "code" | "strong",
+  nextText: string,
+) {
+  const normalized = html.replaceAll("&nbsp;", " ");
+  const closeIndex = normalized.indexOf(`</${tag}>`);
+  const nextIndex = normalized.indexOf(nextText);
+  return closeIndex >= 0 && nextIndex > closeIndex;
+}
+
+describe("note editor markdown input", () => {
+  const { getPage } = setupBrowser();
+
+  it("Markdown pasteでlist/code/tableをeditor HTMLに変換できる", async () => {
+    const page = getPage();
+
+    await login(page, "e2e@example.com", "password123");
+    await openNewNote(page);
+
+    const editor = getNoteEditor(page);
+    await pasteMarkdownIntoNoteEditor(
+      editor,
+      [
+        "# Paste Heading",
+        "",
+        "- one",
+        "- two",
+        "",
+        "`inline` and **bold**",
+        "",
+        "```",
+        "const answer = 42;",
+        "```",
+        "",
+        "| A | B |",
+        "| --- | --- |",
+        "| alpha | beta |",
+      ].join("\n"),
+    );
+
+    await editor.locator("h1").waitFor({ state: "visible", timeout: 15000 });
+    await expect.poll(() => editor.locator("li").count()).toBe(2);
+    await editor.locator("pre code").waitFor({ state: "visible" });
+    await editor.locator("table").waitFor({ state: "visible" });
+
+    expect(await editor.locator("h1").textContent()).toBe("Paste Heading");
+    expect(await editor.locator("li").allTextContents()).toEqual([
+      "one",
+      "two",
+    ]);
+    expect(await editor.locator("p code").textContent()).toBe("inline");
+    expect(await editor.locator("strong").textContent()).toBe("bold");
+    expect((await editor.locator("pre code").textContent())?.trimEnd()).toBe(
+      "const answer = 42;",
+    );
+    expect(await editor.locator("th").allTextContents()).toEqual(["A", "B"]);
+    expect(await editor.locator("td").allTextContents()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("inline styleの末尾から右矢印とタップで外へ出られる", async () => {
+    const page = getPage();
+
+    await login(page, "e2e@example.com", "password123");
+    await openNewNote(page);
+
+    const editor = getNoteEditor(page);
+    await setNoteEditorHtml(editor, "<p><strong>bold</strong></p>", "strong");
+    await editor.evaluate((element) => {
+      element.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "ArrowRight",
+        }),
+      );
+    });
+    await editor.pressSequentially(" after");
+
+    const strongExitHtml = await editor.evaluate(
+      (element) => element.innerHTML,
+    );
+    expect(isOutsideInline(strongExitHtml, "strong", "after")).toBe(true);
+
+    await setNoteEditorHtml(editor, "<p><code>code</code></p>", "code");
+    const codeBox = await editor.locator("code").boundingBox();
+    expect(codeBox).not.toBeNull();
+    await page.mouse.click(
+      codeBox!.x + codeBox!.width - 2,
+      codeBox!.y + codeBox!.height / 2,
+    );
+    await editor.pressSequentially(" next");
+
+    const codeExitHtml = await editor.evaluate((element) => element.innerHTML);
+    expect(isOutsideInline(codeExitHtml, "code", "next")).toBe(true);
+  });
+
+  it("code blockはShift+Enterで改行し、空行のEnterで通常段落へ出る", async () => {
+    const page = getPage();
+
+    await login(page, "e2e@example.com", "password123");
+    await openNewNote(page);
+
+    const editor = getNoteEditor(page);
+    await setNoteEditorHtml(editor, "<pre><code>one</code></pre>", "code");
+
+    await editor.press("Shift+Enter");
+    await editor.pressSequentially("two");
+    await editor.press("Enter");
+    await editor.press("Enter");
+    await editor.pressSequentially("after");
+
+    expect(await editor.locator("pre code").textContent()).toBe("one\ntwo");
+    expect(await editor.locator("p").last().textContent()).toContain("after");
+  });
+
+  it("**bold**変換後の続きはstrongの外に入る", async () => {
+    const page = getPage();
+
+    await login(page, "e2e@example.com", "password123");
+    await openNewNote(page);
+
+    const editor = getNoteEditor(page);
+    await setNoteEditorHtml(editor, "<p>**bold**</p>");
+    await editor.locator("strong").waitFor({ state: "visible" });
+    await editor.pressSequentially(" after");
+
+    const html = await editor.evaluate((element) => element.innerHTML);
+    expect(isOutsideInline(html, "strong", "after")).toBe(true);
+  });
+});

--- a/e2e/web/noteMarkdownPersistence.test.ts
+++ b/e2e/web/noteMarkdownPersistence.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { login } from "../helpers/auth";
+import { setupBrowser } from "../helpers/browser";
+import {
+  getNoteEditor,
+  openNewNote,
+  pasteMarkdownIntoNoteEditor,
+  saveNote,
+} from "../helpers/note";
+
+describe("note markdown persistence", () => {
+  const { getPage } = setupBrowser();
+
+  it("Markdownで書いたnoteを保存し、再表示してもmarkupが維持される", async () => {
+    const page = getPage();
+    const title = `E2E Markdown保存 ${Date.now()}`;
+
+    await login(page, "e2e@example.com", "password123");
+    await openNewNote(page);
+
+    await page.fill('input[placeholder="ノートのタイトル"]', title);
+
+    const editor = getNoteEditor(page);
+    await pasteMarkdownIntoNoteEditor(
+      editor,
+      [
+        "# Saved Heading",
+        "",
+        "- one",
+        "- two",
+        "",
+        "`inline` and **bold**",
+        "",
+        "```",
+        "const saved = true;",
+        "```",
+        "",
+        "| A | B |",
+        "| --- | --- |",
+        "| alpha | beta |",
+      ].join("\n"),
+    );
+
+    await editor.locator("table").waitFor({ state: "visible", timeout: 15000 });
+    await page
+      .locator('button:has-text("保存")')
+      .waitFor({ state: "visible", timeout: 15000 });
+    await expect
+      .poll(() => page.locator('button:has-text("保存")').isEnabled())
+      .toBe(true);
+
+    await saveNote(page);
+    await page.waitForURL("**/notes", { timeout: 15000 });
+    await page.waitForSelector(`text="${title}"`, { timeout: 15000 });
+    await page
+      .locator("button")
+      .filter({ hasText: title })
+      .filter({ hasText: "Saved Heading" })
+      .first()
+      .waitFor({ state: "visible", timeout: 15000 });
+
+    await page.locator("button").filter({ hasText: title }).first().click();
+    await page.waitForURL("**/notes/*", { timeout: 15000 });
+
+    const reopenedEditor = getNoteEditor(page);
+    await reopenedEditor
+      .locator("h1")
+      .waitFor({ state: "visible", timeout: 15000 });
+    await reopenedEditor.locator("table").waitFor({ state: "visible" });
+
+    expect(await reopenedEditor.locator("h1").textContent()).toBe(
+      "Saved Heading",
+    );
+    expect(await reopenedEditor.locator("li").allTextContents()).toEqual([
+      "one",
+      "two",
+    ]);
+    expect(await reopenedEditor.locator("p code").textContent()).toBe("inline");
+    expect(await reopenedEditor.locator("strong").textContent()).toBe("bold");
+    expect(
+      (await reopenedEditor.locator("pre code").textContent())?.trimEnd(),
+    ).toBe("const saved = true;");
+    expect(await reopenedEditor.locator("th").allTextContents()).toEqual([
+      "A",
+      "B",
+    ]);
+    expect(await reopenedEditor.locator("td").allTextContents()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+});

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -12,6 +12,7 @@
     "rehype-remark": "^10.0.1",
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
+    "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "remark-stringify": "^11.0.0",

--- a/packages/frontend-shared/utils/noteRichText.test.ts
+++ b/packages/frontend-shared/utils/noteRichText.test.ts
@@ -13,34 +13,68 @@ import {
 describe("noteRichText", () => {
   test("markdownをeditor htmlへ変換できる", () => {
     const html = markdownToNoteEditorHtml(
-      "# Title\n\n**bold** and *italic*\n\n- one\n- two",
+      "# Title\n\n**bold** and *italic* and `code`\n\n- one\n- two\n\n| A | B |\n| --- | --- |\n| one | two |",
     );
 
     expect(html).toContain("<h1>Title</h1>");
     expect(html).toContain("<strong>bold</strong>");
     expect(html).toContain("<em>italic</em>");
+    expect(html).toContain("<code>code</code>");
     expect(html).toContain("<ul>");
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>A</th>");
   });
 
   test("editor htmlをmarkdownへ戻せる", () => {
     const markdown = noteEditorHtmlToMarkdown(
-      "<h2>Heading</h2><p><strong>bold</strong> text</p><blockquote><p>quote</p></blockquote><ol><li>one</li><li>two</li></ol><pre><code>const x = 1;\nconsole.log(x);\n</code></pre>",
+      "<h2>Heading</h2><p><strong>bold</strong> <code>text</code></p><blockquote><p>quote</p></blockquote><ol><li>one</li><li>two</li></ol><pre><code>const x = 1;\nconsole.log(x);\n</code></pre><table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>one</td><td>two</td></tr></tbody></table>",
     );
 
     expect(markdown).toContain("## Heading");
-    expect(markdown).toContain("**bold** text");
+    expect(markdown).toContain("**bold** `text`");
     expect(markdown).toContain("> quote");
     expect(markdown).toContain("1. one");
     expect(markdown).toContain("```");
     expect(markdown).toContain("const x = 1;");
+    expect(markdown).toMatch(/\| A\s+\| B\s+\|/);
+    expect(markdown).toMatch(/\| one \| two \|/);
   });
 
   test("不要なhtmlはmarkdown保存前に落とす", () => {
     const markdown = noteEditorHtmlToMarkdown(
-      '<p>Hello<script>alert("x")</script><span style="color:red"> world</span></p>',
+      '<p>Hello\u200B<script>alert("x")</script><span style="color:red"> world</span></p>',
     );
 
     expect(markdown).toBe("Hello world");
+  });
+
+  test("GFM tableをmarkdownとして往復できる", () => {
+    const source = [
+      "| Name | Value |",
+      "| --- | --- |",
+      "| alpha | 1 |",
+      "| beta | 2 |",
+    ].join("\n");
+
+    const html = markdownToNoteEditorHtml(source);
+    const markdown = noteEditorHtmlToMarkdown(html);
+
+    expect(html).toContain("<table>");
+    expect(html).toContain("<td>alpha</td>");
+    expect(markdown).toMatch(/\| Name\s+\| Value\s+\|/);
+    expect(markdown).toMatch(/\| alpha \| 1\s+\|/);
+    expect(markdown).toMatch(/\| beta\s+\| 2\s+\|/);
+  });
+
+  test("code blockをmarkdownとして往復できる", () => {
+    const source = "```\nconst x = 1;\nconsole.log(x);\n```";
+
+    const html = markdownToNoteEditorHtml(source);
+    const markdown = noteEditorHtmlToMarkdown(html);
+
+    expect(html).toContain("<pre><code>const x = 1;");
+    expect(markdown).toContain("```");
+    expect(markdown).toContain("console.log(x);");
   });
 
   test("markdownから一覧表示向けのpreview textを作れる", () => {
@@ -69,6 +103,7 @@ describe("noteRichText", () => {
   test("paste用に単一段落のplain textは<p>を外してinline挿入できる形にする", () => {
     expect(markdownToNotePasteHtml("hello world")).toBe("hello world");
     expect(markdownToNotePasteHtml("**bold**")).toBe("<strong>bold</strong>");
+    expect(markdownToNotePasteHtml("`code`")).toBe("<code>code</code>");
     expect(markdownToNotePasteHtml("")).toBe("");
   });
 
@@ -76,6 +111,17 @@ describe("noteRichText", () => {
     const html = markdownToNotePasteHtml("# Title\n\n- one\n- two");
     expect(html).toContain("<h1>Title</h1>");
     expect(html).toContain("<ul>");
+  });
+
+  test("paste用にtableとcode blockをブロック要素のHTMLとして返す", () => {
+    const tableHtml = markdownToNotePasteHtml(
+      "| A | B |\n| --- | --- |\n| one | two |",
+    );
+    const codeHtml = markdownToNotePasteHtml("```\nconst x = 1;\n```");
+
+    expect(tableHtml).toContain("<table>");
+    expect(tableHtml).toContain("<td>one</td>");
+    expect(codeHtml).toContain("<pre><code>const x = 1;");
   });
 
   test("paste用に複数段落のplain textはそのまま<p>を保持する", () => {
@@ -92,8 +138,13 @@ describe("noteRichText", () => {
     expect(looksLikeNoteMarkdown("1. item")).toBe(true);
     expect(looksLikeNoteMarkdown("> quote")).toBe(true);
     expect(looksLikeNoteMarkdown("text with **bold** inline")).toBe(true);
+    expect(looksLikeNoteMarkdown("text with `code` inline")).toBe(true);
     expect(looksLikeNoteMarkdown("see [link](https://example.com)")).toBe(true);
     expect(looksLikeNoteMarkdown("```\ncode\n```")).toBe(true);
+    expect(
+      looksLikeNoteMarkdown("| A | B |\n| --- | --- |\n| one | two |"),
+    ).toBe(true);
+    expect(looksLikeNoteMarkdown("plain text with | pipe")).toBe(false);
     expect(looksLikeNoteMarkdown("just plain text with no markers")).toBe(
       false,
     );
@@ -118,8 +169,12 @@ describe("noteRichText", () => {
 
   test("block先頭のmarkdown shortcutを判定できる", () => {
     expect(matchNoteBlockMarkdownShortcut("#")).toBe("heading1");
+    expect(matchNoteBlockMarkdownShortcut("# Title")).toBe("heading1");
     expect(matchNoteBlockMarkdownShortcut("-")).toBe("bulletList");
+    expect(matchNoteBlockMarkdownShortcut("- item")).toBe("bulletList");
+    expect(matchNoteBlockMarkdownShortcut("1. item")).toBe("orderedList");
     expect(matchNoteBlockMarkdownShortcut(">")).toBe("blockquote");
+    expect(matchNoteBlockMarkdownShortcut("> quote")).toBe("blockquote");
     expect(matchNoteBlockMarkdownShortcut("```")).toBe("codeBlock");
     expect(matchNoteBlockMarkdownShortcut("##")).toBeNull();
     expect(matchNoteBlockMarkdownShortcut("text")).toBeNull();

--- a/packages/frontend-shared/utils/noteRichText.ts
+++ b/packages/frontend-shared/utils/noteRichText.ts
@@ -2,13 +2,14 @@ import rehypeParse from "rehype-parse";
 import rehypeRemark from "rehype-remark";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeStringify from "rehype-stringify";
+import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
 
 export const NOTE_RICH_TEXT_EDITOR_SOURCE = "note-rich-text-editor";
-const EMPTY_EDITOR_HTML = "<p></p>";
+const EMPTY_EDITOR_HTML = "<p><br></p>";
 
 export type NoteRichTextCommand =
   | "bold"
@@ -68,11 +69,18 @@ const noteEditorSchema = {
     "blockquote",
     "pre",
     "code",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
   ],
 };
 
 const markdownToHtmlProcessor = unified()
   .use(remarkParse)
+  .use(remarkGfm)
   .use(remarkRehype)
   .use(rehypeSanitize, noteEditorSchema)
   .use(rehypeStringify);
@@ -81,6 +89,7 @@ const htmlToMarkdownProcessor = unified()
   .use(rehypeParse, { fragment: true })
   .use(rehypeSanitize, noteEditorSchema)
   .use(rehypeRemark)
+  .use(remarkGfm)
   .use(remarkStringify, {
     bullet: "-",
     emphasis: "*",
@@ -123,6 +132,7 @@ function escapeHtml(text: string) {
 
 function normalizeEditorHtml(html: string) {
   return html
+    .replaceAll("\u200B", "")
     .replaceAll("&nbsp;", " ")
     .replace(/<\/?span[^>]*>/g, "")
     .replace(/<div(?=[\s>])/g, "<p")
@@ -153,6 +163,8 @@ const markdownDetectionPatterns: RegExp[] = [
   /^\s{0,3}\d+\. /m,
   /^\s{0,3}> /m,
   /```/,
+  /^\s*\|?.+\|.+\n\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/m,
+  /`[^`\n]+`/,
   /\*\*[^*\n]+\*\*/,
   /(^|\s)\*[^*\s][^*\n]*\*(\s|$)/,
   /\[[^\]\n]+\]\([^)\n]+\)/,
@@ -164,7 +176,13 @@ export function looksLikeNoteMarkdown(text: string) {
 }
 
 export function matchNoteBlockMarkdownShortcut(text: string) {
-  const normalized = text.replaceAll("\u00a0", " ");
+  const normalized = text.replaceAll("\u00a0", " ").trimEnd();
+  if (/^#{1}\s+.+/.test(normalized)) return "heading1";
+  if (/^#{2}\s+.+/.test(normalized)) return "heading2";
+  if (/^[-*+]\s+.+/.test(normalized)) return "bulletList";
+  if (/^\d+\.\s+.+/.test(normalized)) return "orderedList";
+  if (/^>\s+.+/.test(normalized)) return "blockquote";
+  if (/^```/.test(normalized)) return "codeBlock";
   const matchedShortcut = markdownShortcutEntries.find(
     ({ trigger }) => trigger === normalized,
   );
@@ -374,7 +392,7 @@ export function createNoteRichTextEditorDocument({
       }
 
       .toolbar {
-        display: flex;
+        display: none;
         flex-wrap: wrap;
         gap: 8px;
         padding: 12px;
@@ -485,6 +503,42 @@ export function createNoteRichTextEditorDocument({
         font-size: 0.9375rem;
       }
 
+      #editor :not(pre) > code {
+        border-radius: 6px;
+        background: ${palette.codeBackground};
+        padding: 0.1em 0.35em;
+        font-family:
+          ui-monospace,
+          SFMono-Regular,
+          Menlo,
+          Monaco,
+          Consolas,
+          "Liberation Mono",
+          "Courier New",
+          monospace;
+        font-size: 0.92em;
+      }
+
+      #editor table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 0 0 1em;
+        font-size: 0.95rem;
+      }
+
+      #editor th,
+      #editor td {
+        border: 1px solid ${palette.border};
+        padding: 0.5em 0.65em;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      #editor th {
+        background: ${palette.buttonBackground};
+        font-weight: 700;
+      }
+
       #editor strong {
         font-weight: 700;
       }
@@ -508,6 +562,7 @@ export function createNoteRichTextEditorDocument({
         let applyingExternalUpdate = false;
         let lastSentHtml = "";
         let lastSentHeight = 0;
+        const caretMarker = String.fromCharCode(8203);
 
         const postMessage = (payload) => {
           const serialized = JSON.stringify({ source: config.source, ...payload });
@@ -520,7 +575,7 @@ export function createNoteRichTextEditorDocument({
         };
 
         const updateEmptyState = () => {
-          const text = editor.textContent?.replace(/\\u200B/g, "").trim() ?? "";
+          const text = editor.textContent?.replaceAll(caretMarker, "").trim() ?? "";
           editor.dataset.empty = text.length === 0 ? "true" : "false";
         };
 
@@ -583,6 +638,373 @@ export function createNoteRichTextEditorDocument({
           focusEditor();
         };
 
+        const getElementFromNode = (node) => {
+          if (!node) return null;
+          if (node.nodeType === Node.ELEMENT_NODE) return node;
+          return node.parentElement ||
+            (node.parentNode instanceof HTMLElement ? node.parentNode : null);
+        };
+
+        const getInlineStyleElement = (node) => {
+          const element = getElementFromNode(node);
+          const inline = element?.closest("strong, code");
+          if (!(inline instanceof HTMLElement)) return null;
+          if (inline.tagName === "CODE" && inline.closest("pre")) return null;
+          return editor.contains(inline) ? inline : null;
+        };
+
+        const placeCaretAfterInlineStyle = (inline) => {
+          let caretNode = inline.nextSibling;
+          if (!(caretNode instanceof Text)) {
+            caretNode = document.createTextNode(caretMarker);
+            inline.after(caretNode);
+          } else if (!caretNode.textContent?.startsWith(caretMarker)) {
+            caretNode.textContent = caretMarker + (caretNode.textContent || "");
+          }
+          setCaret(caretNode, 1);
+        };
+
+        const removeCaretMarkers = () => {
+          const selection = document.getSelection();
+          const anchorNode = selection?.anchorNode ?? null;
+          const anchorOffset = selection?.anchorOffset ?? 0;
+          let nextAnchorOffset = anchorOffset;
+          let shouldRestoreSelection = false;
+
+          const walker = document.createTreeWalker(
+            editor,
+            NodeFilter.SHOW_TEXT,
+          );
+          const textNodes = [];
+          while (walker.nextNode()) {
+            textNodes.push(walker.currentNode);
+          }
+
+          textNodes.forEach((node) => {
+            const text = node.textContent || "";
+            if (!text.includes(caretMarker)) return;
+
+            if (node === anchorNode) {
+              const beforeCaret = text.slice(0, anchorOffset);
+              nextAnchorOffset =
+                anchorOffset -
+                beforeCaret.split(caretMarker).length +
+                1;
+              shouldRestoreSelection = true;
+            }
+
+            node.textContent = text.replaceAll(caretMarker, "");
+          });
+
+          if (shouldRestoreSelection && anchorNode?.isConnected) {
+            setCaret(anchorNode, Math.max(0, nextAnchorOffset));
+          }
+        };
+
+        const setCaretToEnd = (element) => {
+          const selection = document.getSelection();
+          if (!selection) return;
+
+          const lastChild = element.lastChild;
+          const inline = getInlineStyleElement(lastChild);
+          if (inline && inline === lastChild) {
+            placeCaretAfterInlineStyle(inline);
+            return;
+          }
+
+          const range = document.createRange();
+          range.selectNodeContents(element);
+          range.collapse(false);
+          selection.removeAllRanges();
+          selection.addRange(range);
+          focusEditor();
+        };
+
+        const textWithLineBreaks = (node) => {
+          if (node.nodeType === Node.TEXT_NODE) {
+            return node.textContent || "";
+          }
+          if (node instanceof HTMLBRElement) {
+            return "\\n";
+          }
+          return Array.from(node.childNodes).map(textWithLineBreaks).join("");
+        };
+
+        const isCaretAtBlockEnd = (block, range) => {
+          const trailingRange = range.cloneRange();
+          trailingRange.selectNodeContents(block);
+          trailingRange.setStart(range.endContainer, range.endOffset);
+          return trailingRange.toString().replace(/\\u200B/g, "").trim().length === 0;
+        };
+
+        const appendInlineMarkdown = (parent, text) => {
+          const pattern = /(\\x60[^\\x60\\n]+\\x60|\\*\\*[^*\\n]+\\*\\*)/g;
+          let lastIndex = 0;
+
+          for (const match of text.matchAll(pattern)) {
+            if (match.index > lastIndex) {
+              parent.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+            }
+
+            const token = match[0];
+            const element = token.startsWith(String.fromCharCode(96))
+              ? document.createElement("code")
+              : document.createElement("strong");
+            element.textContent = token.startsWith(String.fromCharCode(96))
+              ? token.slice(1, -1)
+              : token.slice(2, -2);
+            parent.appendChild(element);
+            lastIndex = match.index + token.length;
+          }
+
+          if (lastIndex < text.length) {
+            parent.appendChild(document.createTextNode(text.slice(lastIndex)));
+          }
+        };
+
+        const parseMarkdownTable = (text) => {
+          const lines = text
+            .split("\\n")
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+          if (lines.length < 3) return null;
+
+          const separatorPattern = /^\\|?\\s*:?-{3,}:?\\s*(\\|\\s*:?-{3,}:?\\s*)+\\|?$/;
+          if (!separatorPattern.test(lines[1])) return null;
+
+          const toCells = (line) => {
+            const normalized = line.replace(/^[|]/, "").replace(/[|]$/, "");
+            return normalized.split("|").map((cell) => cell.trim());
+          };
+          const headers = toCells(lines[0]);
+          const separators = toCells(lines[1]);
+          const rows = lines.slice(2).map(toCells);
+          if (headers.length < 2 || separators.length !== headers.length) {
+            return null;
+          }
+          if (rows.some((row) => row.length !== headers.length)) {
+            return null;
+          }
+
+          return { headers, rows };
+        };
+
+        const buildMarkdownTable = ({ headers, rows }) => {
+          const table = document.createElement("table");
+          const thead = document.createElement("thead");
+          const headRow = document.createElement("tr");
+          headers.forEach((header) => {
+            const th = document.createElement("th");
+            appendInlineMarkdown(th, header);
+            headRow.appendChild(th);
+          });
+          thead.appendChild(headRow);
+          table.appendChild(thead);
+
+          const tbody = document.createElement("tbody");
+          rows.forEach((row) => {
+            const tr = document.createElement("tr");
+            row.forEach((cell) => {
+              const td = document.createElement("td");
+              appendInlineMarkdown(td, cell);
+              tr.appendChild(td);
+            });
+            tbody.appendChild(tr);
+          });
+          table.appendChild(tbody);
+          return table;
+        };
+
+        const isMarkdownBlockStart = (line) =>
+          /^\\s*$/.test(line) ||
+          /^#{1,2}\\s+/.test(line) ||
+          /^[-*+]\\s+/.test(line) ||
+          /^\\d+\\.\\s+/.test(line) ||
+          /^>\\s+/.test(line) ||
+          /^\\s*\\|?.+\\|.+/.test(line) ||
+          /^\\s*\\x60\\x60\\x60/.test(line);
+
+        const buildMarkdownFragment = (text) => {
+          const lines = text.split("\\n");
+          const hasMarkdown = lines.some((line, index) => {
+            if (/^#{1,2}\\s+/.test(line)) return true;
+            if (/^[-*+]\\s+/.test(line)) return true;
+            if (/^\\d+\\.\\s+/.test(line)) return true;
+            if (/^>\\s+/.test(line)) return true;
+            if (/\\x60[^\\x60]+\\x60/.test(line)) return true;
+            if (/\\*\\*[^*]+\\*\\*/.test(line)) return true;
+            if (/^\\s*\\x60\\x60\\x60/.test(line)) {
+              return lines
+                .slice(index + 1)
+                .some((nextLine) => /^\\s*\\x60\\x60\\x60\\s*$/.test(nextLine));
+            }
+            if (index + 1 < lines.length) {
+              return parseMarkdownTable(lines.slice(index).join("\\n")) !== null;
+            }
+            return false;
+          });
+          if (!hasMarkdown) return null;
+
+          const fragment = document.createDocumentFragment();
+          let focusTarget = null;
+          let index = 0;
+
+          const appendBlock = (element, target = element) => {
+            fragment.appendChild(element);
+            focusTarget = target;
+          };
+
+          while (index < lines.length) {
+            const line = lines[index];
+            if (!line.trim()) {
+              index += 1;
+              continue;
+            }
+
+            if (/^\\s*\\x60\\x60\\x60/.test(line)) {
+              const closingIndex = lines
+                .slice(index + 1)
+                .findIndex((nextLine) =>
+                  /^\\s*\\x60\\x60\\x60\\s*$/.test(nextLine),
+                );
+              if (closingIndex < 0) {
+                const paragraph = document.createElement("p");
+                appendInlineMarkdown(paragraph, line);
+                appendBlock(paragraph);
+                index += 1;
+                continue;
+              }
+              const codeLines = [];
+              index += 1;
+              while (index < lines.length && !/^\\s*\\x60\\x60\\x60\\s*$/.test(lines[index])) {
+                codeLines.push(lines[index]);
+                index += 1;
+              }
+              if (index < lines.length) {
+                index += 1;
+              }
+              const pre = document.createElement("pre");
+              const code = document.createElement("code");
+              code.textContent = codeLines.join("\\n");
+              pre.appendChild(code);
+              appendBlock(pre, code);
+              continue;
+            }
+
+            const remainingText = lines.slice(index).join("\\n");
+            const table = parseMarkdownTable(remainingText);
+            if (table) {
+              const tableElement = buildMarkdownTable(table);
+              appendBlock(
+                tableElement,
+                tableElement.querySelector("tbody tr:last-child td:last-child") || tableElement,
+              );
+              index += table.rows.length + 2;
+              continue;
+            }
+
+            const unordered = /^[-*+]\\s+(.+)$/.exec(line);
+            if (unordered) {
+              const list = document.createElement("ul");
+              while (index < lines.length) {
+                const match = /^[-*+]\\s+(.+)$/.exec(lines[index]);
+                if (!match) break;
+                const item = document.createElement("li");
+                appendInlineMarkdown(item, match[1]);
+                list.appendChild(item);
+                focusTarget = item;
+                index += 1;
+              }
+              appendBlock(list, focusTarget || list);
+              continue;
+            }
+
+            const ordered = /^\\d+\\.\\s+(.+)$/.exec(line);
+            if (ordered) {
+              const list = document.createElement("ol");
+              while (index < lines.length) {
+                const match = /^\\d+\\.\\s+(.+)$/.exec(lines[index]);
+                if (!match) break;
+                const item = document.createElement("li");
+                appendInlineMarkdown(item, match[1]);
+                list.appendChild(item);
+                focusTarget = item;
+                index += 1;
+              }
+              appendBlock(list, focusTarget || list);
+              continue;
+            }
+
+            const heading = /^(#{1,2})\\s+(.+)$/.exec(line);
+            if (heading) {
+              const block = document.createElement(heading[1].length === 1 ? "h1" : "h2");
+              appendInlineMarkdown(block, heading[2]);
+              appendBlock(block);
+              index += 1;
+              continue;
+            }
+
+            const quote = /^>\\s+(.+)$/.exec(line);
+            if (quote) {
+              const blockquote = document.createElement("blockquote");
+              appendInlineMarkdown(blockquote, quote[1]);
+              appendBlock(blockquote);
+              index += 1;
+              continue;
+            }
+
+            const paragraph = document.createElement("p");
+            while (index < lines.length && !isMarkdownBlockStart(lines[index])) {
+              if (paragraph.childNodes.length > 0) {
+                paragraph.appendChild(document.createElement("br"));
+              }
+              appendInlineMarkdown(paragraph, lines[index]);
+              index += 1;
+            }
+            if (paragraph.childNodes.length === 0) {
+              appendInlineMarkdown(paragraph, line);
+              index += 1;
+            }
+            appendBlock(paragraph);
+          }
+
+          if (!fragment.childNodes.length || !focusTarget) return null;
+          return { fragment, focusTarget };
+        };
+
+        const convertCurrentBlockMarkdown = () => {
+          const context = getCurrentBlockContext();
+          if (!context) return false;
+          if (context.block !== editor && context.block.tagName !== "P") return false;
+          if (!isCaretAtBlockEnd(context.block, context.range)) return false;
+
+          const text = textWithLineBreaks(context.block)
+            .replace(/\\u00a0/g, " ")
+            .replace(/\\u200B/g, "")
+            .trimEnd();
+          if (!text.trim()) return false;
+
+          const markdownFragment = buildMarkdownFragment(text);
+          if (markdownFragment) {
+            if (context.block === editor) {
+              editor.replaceChildren(markdownFragment.fragment);
+            } else {
+              context.block.replaceWith(markdownFragment.fragment);
+            }
+            setCaretToEnd(markdownFragment.focusTarget);
+            window.requestAnimationFrame(emitChange);
+            return true;
+          }
+
+          return false;
+        };
+
+        const scheduleMarkdownConversion = () => {
+          window.requestAnimationFrame(() => {
+            convertCurrentBlockMarkdown();
+          });
+        };
+
         const formatBlock = (tagName) => {
           document.execCommand("formatBlock", false, "<" + tagName + ">");
         };
@@ -639,6 +1061,65 @@ export function createNoteRichTextEditorDocument({
           }
         };
 
+        const getRangeText = (block, range, boundary) => {
+          const textRange = document.createRange();
+          textRange.selectNodeContents(block);
+          if (boundary === "before") {
+            textRange.setEnd(range.endContainer, range.endOffset);
+          } else {
+            textRange.setStart(range.startContainer, range.startOffset);
+          }
+          const container = document.createElement("div");
+          container.appendChild(textRange.cloneContents());
+          return textWithLineBreaks(container).replace(/\\u200B/g, "");
+        };
+
+        const isCurrentCodeLineEmpty = (pre, range) => {
+          const beforeCaret = getRangeText(pre, range, "before");
+          const currentLine = beforeCaret.split("\\n").at(-1) || "";
+          return beforeCaret.length > 0 && currentLine.trim().length === 0;
+        };
+
+        const exitCodeBlock = (pre, range) => {
+          const beforeCaret = getRangeText(pre, range, "before").replace(
+            /\\n[ \\t]*$/,
+            "",
+          );
+          const afterCaret = getRangeText(pre, range, "after").replace(
+            /^[ \\t]*\\n/,
+            "",
+          );
+          const code = pre.querySelector("code") || pre;
+          code.textContent = beforeCaret;
+
+          const paragraph = document.createElement("p");
+          if (afterCaret.trim()) {
+            paragraph.textContent = afterCaret;
+          } else {
+            paragraph.appendChild(document.createElement("br"));
+          }
+          pre.after(paragraph);
+          setCaret(paragraph, 0);
+
+          if (!code.textContent?.trim()) {
+            pre.remove();
+          }
+        };
+
+        const isCaretAtInlineStyleEnd = (inline, range) => {
+          if (
+            range.endContainer !== inline &&
+            !inline.contains(range.endContainer)
+          ) {
+            return false;
+          }
+
+          const trailingRange = range.cloneRange();
+          trailingRange.selectNodeContents(inline);
+          trailingRange.setStart(range.endContainer, range.endOffset);
+          return trailingRange.toString().replace(/\\u200B/g, "").length === 0;
+        };
+
         const getCurrentBlockContext = () => {
           const selection = document.getSelection();
           if (!selection || !selection.rangeCount || !selection.isCollapsed) {
@@ -650,13 +1131,23 @@ export function createNoteRichTextEditorDocument({
           const parentElement =
             anchorNode?.nodeType === Node.ELEMENT_NODE
               ? anchorNode
-              : anchorNode?.parentElement;
+              : anchorNode?.parentElement ||
+                (anchorNode?.parentNode instanceof HTMLElement
+                  ? anchorNode.parentNode
+                  : null);
           const block = parentElement?.closest("p, h1, h2, blockquote, li");
+          if (block instanceof HTMLElement) {
+            return { block, range };
+          }
+
+          const root = parentElement?.closest("#editor");
+          if (root === editor) {
+            return { block: editor, range };
+          }
+
           if (!(block instanceof HTMLElement)) {
             return null;
           }
-
-          return { block, range };
         };
 
         const getMarkdownShortcutCommand = (text) => {
@@ -777,6 +1268,28 @@ export function createNoteRichTextEditorDocument({
           reportHeight();
         };
 
+        const handleInlineStyleExit = (event) => {
+          if (event.key !== "ArrowRight") return false;
+          if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+            return false;
+          }
+
+          const selection = document.getSelection();
+          if (!selection || !selection.rangeCount || !selection.isCollapsed) {
+            return false;
+          }
+
+          const range = selection.getRangeAt(0);
+          const inline = getInlineStyleElement(selection.anchorNode);
+          if (!inline || !isCaretAtInlineStyleEnd(inline, range)) {
+            return false;
+          }
+
+          event.preventDefault();
+          placeCaretAfterInlineStyle(inline);
+          return true;
+        };
+
         const handleEnter = (event) => {
           if (event.key !== "Enter") return;
           if (event.isComposing) return;
@@ -786,7 +1299,22 @@ export function createNoteRichTextEditorDocument({
           const parentElement =
             context.range.startContainer?.nodeType === Node.ELEMENT_NODE
               ? context.range.startContainer
-              : context.range.startContainer?.parentElement;
+              : context.range.startContainer?.parentElement ||
+                (context.range.startContainer?.parentNode instanceof HTMLElement
+                  ? context.range.startContainer.parentNode
+                  : null);
+          const pre = parentElement?.closest("pre");
+          if (pre instanceof HTMLElement) {
+            event.preventDefault();
+            if (event.shiftKey || !isCurrentCodeLineEmpty(pre, context.range)) {
+              insertLineBreak();
+            } else {
+              exitCodeBlock(pre, context.range);
+            }
+            window.requestAnimationFrame(emitChange);
+            return;
+          }
+
           const headingBlock =
             context.block.tagName === "H1" || context.block.tagName === "H2"
               ? context.block
@@ -825,6 +1353,24 @@ export function createNoteRichTextEditorDocument({
           formatBlock("p");
           window.requestAnimationFrame(emitChange);
           return;
+        };
+
+        const handleKeyDown = (event) => {
+          if (handleInlineStyleExit(event)) return;
+          handleEnter(event);
+        };
+
+        const handleInlineStylePointerUp = (event) => {
+          const inline = getInlineStyleElement(event.target);
+          if (!inline) return;
+
+          const rect = inline.getBoundingClientRect();
+          const exitZoneWidth = Math.max(8, Math.min(18, rect.width * 0.35));
+          if (event.clientX < rect.right - exitZoneWidth) return;
+
+          window.requestAnimationFrame(() => {
+            placeCaretAfterInlineStyle(inline);
+          });
         };
 
         const handleMarkdownShortcut = (event) => {
@@ -885,11 +1431,14 @@ export function createNoteRichTextEditorDocument({
           runCommand(target.dataset.command);
         });
 
-        editor.addEventListener("keydown", handleEnter);
+        editor.addEventListener("keydown", handleKeyDown);
+        editor.addEventListener("pointerup", handleInlineStylePointerUp);
         editor.addEventListener("beforeinput", handleMarkdownShortcut);
-        editor.addEventListener("input", () =>
-          window.requestAnimationFrame(emitChange),
-        );
+        editor.addEventListener("input", () => {
+          removeCaretMarkers();
+          scheduleMarkdownConversion();
+          window.requestAnimationFrame(emitChange);
+        });
         const markdownDetectionRegexes = (config.markdownDetectionPatterns || []).map(
           (entry) => new RegExp(entry.source, entry.flags),
         );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       rehype-stringify:
         specifier: ^10.0.1
         version: 10.0.1
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
@@ -4579,6 +4582,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -5839,6 +5846,9 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   marked@17.0.4:
     resolution: {integrity: sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==}
     engines: {node: '>= 20'}
@@ -5851,8 +5861,29 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -5955,6 +5986,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -6714,6 +6766,9 @@ packages:
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -11908,6 +11963,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   esprima@4.0.1: {}
 
   estree-util-is-identifier-name@3.0.0: {}
@@ -13321,11 +13378,20 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  markdown-table@3.0.4: {}
+
   marked@17.0.4: {}
 
   marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -13341,6 +13407,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13622,6 +13745,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -14544,6 +14725,17 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
       unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-parse@11.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Support Markdown-driven note editor input for lists, inline code, fenced code blocks, tables, and `**bold**`
- Hide the note editor toolbar and add keyboard/tap exits from inline styles
- Add focused editor E2E, Markdown persistence E2E, and broader note rich text unit coverage

## Verification
- `pnpm vitest run packages/frontend-shared/utils/noteRichText.test.ts`
- `pnpm run tsc`
- `E2E_MAX_FORKS=1 pnpm vitest run --config vitest.e2e.config.ts e2e/web/noteEditor.test.ts e2e/web/noteMarkdownPersistence.test.ts`
- `E2E_MAX_FORKS=1 pnpm vitest run --config vitest.e2e.config.ts e2e/web/notes.test.ts e2e/web/noteEditor.test.ts e2e/web/noteMarkdownPersistence.test.ts`
- `pnpm run test-once`