### PR TITLE
fix(mobile/actiko): カウンターモードのステップ値反映漏れとキーボードを修正

### DIFF
--- a/apps/mobile/src/components/actiko/RecordingModeSelector.tsx
+++ b/apps/mobile/src/components/actiko/RecordingModeSelector.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { RecordingMode } from "@packages/domain/activity/recordingMode";
 import {
@@ -51,6 +51,18 @@ export function RecordingModeSelector({
     stepsFromConfig(recordingModeConfig).join(", "),
   );
   const savedCounterConfigRef = useRef<string | null>(recordingModeConfig);
+  const lastEmittedConfigRef = useRef<string | null>(recordingModeConfig);
+
+  useEffect(() => {
+    if (recordingModeConfig === lastEmittedConfigRef.current) return;
+    lastEmittedConfigRef.current = recordingModeConfig;
+    setStepsText(stepsFromConfig(recordingModeConfig).join(", "));
+  }, [recordingModeConfig]);
+
+  const emitConfig = (config: string | null) => {
+    lastEmittedConfigRef.current = config;
+    onRecordingModeConfigChange(config);
+  };
 
   const handleModeChange = (mode: RecordingMode) => {
     if (recordingMode === "counter") {
@@ -58,12 +70,12 @@ export function RecordingModeSelector({
     }
     onRecordingModeChange(mode);
     if (mode === "counter" && savedCounterConfigRef.current) {
-      onRecordingModeConfigChange(savedCounterConfigRef.current);
+      emitConfig(savedCounterConfigRef.current);
       setStepsText(stepsFromConfig(savedCounterConfigRef.current).join(", "));
     } else {
       const config = defaultRecordingModeConfig(mode);
       const serialized = serializeRecordingModeConfig(config);
-      onRecordingModeConfigChange(serialized);
+      emitConfig(serialized);
       if (mode === "counter") {
         setStepsText(stepsFromConfig(serialized).join(", "));
       }
@@ -77,7 +89,7 @@ export function RecordingModeSelector({
       .map((s) => Number(s.trim()))
       .filter((n) => !Number.isNaN(n) && n > 0);
     if (parsed.length === 0) return;
-    onRecordingModeConfigChange(
+    emitConfig(
       serializeRecordingModeConfig({ mode: "counter", steps: parsed }),
     );
   };
@@ -126,7 +138,7 @@ export function RecordingModeSelector({
             value={stepsText}
             onChangeText={handleStepsTextChange}
             placeholder="1, 10, 100"
-            keyboardType="numeric"
+            keyboardType="numbers-and-punctuation"
           />
         </View>
       )}


### PR DESCRIPTION
## Summary
mobile の EditActivityDialog で発生していたカウンターモードの 2 件のバグを修正:

- **ステップ値が反映されない**: `RecordingModeSelector` の `stepsText` が `useState` の初期化関数で 1 度しか計算されず、別 activity を開いて `recordingModeConfig` prop が変わっても入力欄が初期値（"1, 10, 100"）のままだった。`useEffect` で同期し、自身が emit した値は ref で識別してタイピング中の再上書きを防ぐ
- **カンマが入力できない**: `keyboardType="numeric"` だと iOS でカンマが打てなかったので `"numbers-and-punctuation"` に変更（Android は未対応 keyboardType → default にフォールバックするので問題なし）

## Test plan
- [ ] カウンターモードで保存済みの activity（例: steps `[5, 25, 50]`）を編集ダイアログで開き、入力欄に `5, 25, 50` が表示されること
- [ ] 入力欄にカンマが打てること（iOS / Android 両方）
- [ ] 入力中の中間文字列（例: `5, 25, `）がリセットされずに保持されること
- [ ] モード切替（counter → timer → counter）で savedCounterConfig が復元されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)