### PR TITLE
feat(stats): 合算統計オフのActivityで合計0のkindグラフを非表示

### DIFF
--- a/apps/frontend/src/components/stats/ActivityStatCard.tsx
+++ b/apps/frontend/src/components/stats/ActivityStatCard.tsx
@@ -1,3 +1,4 @@
+import { getVisibleKindsForCharts } from "@packages/frontend-shared/hooks/getVisibleKindsForCharts";
 import type {
   ActivityStat,
   GoalLine,
@@ -27,6 +28,7 @@ export function ActivityStatCard({
 }) {
   const { t, kindColors, chartData, summary, isSingleUnnamedKind } =
     useActivityStatCard(stat, allDates);
+  const visibleKinds = getVisibleKindsForCharts(stat);
 
   return (
     <div className="border rounded-xl overflow-hidden bg-gray-50">
@@ -68,73 +70,75 @@ export function ActivityStatCard({
       )}
 
       {/* Chart */}
-      <div className="p-4">
-        {stat.showCombinedStats ? (
-          <ActivityChart
-            data={chartData}
-            dataKeys={stat.kinds.map((k) => ({
-              name: k.name,
-              color: kindColors[k.name],
-            }))}
-            stackId="a"
-            showLegend={!isSingleUnnamedKind}
-            goalLines={goalLines}
-          />
-        ) : stat.kinds.length === 1 ? (
-          <ActivityChart
-            data={chartData}
-            dataKeys={[
-              {
-                name: stat.kinds[0].name,
-                color: kindColors[stat.kinds[0].name] || DEFAULT_BAR_COLOR,
-              },
-            ]}
-            showLegend={false}
-            goalLines={goalLines}
-          />
-        ) : (
-          <div className="space-y-4">
-            {stat.kinds.map((kind) => {
-              const kindData = allDates.map((date) => {
-                const matchingLogs = kind.logs.filter(
-                  (l) => dayjs(l.date).format("YYYY-MM-DD") === date,
+      {visibleKinds.length > 0 && (
+        <div className="p-4">
+          {stat.showCombinedStats ? (
+            <ActivityChart
+              data={chartData}
+              dataKeys={visibleKinds.map((k) => ({
+                name: k.name,
+                color: kindColors[k.name],
+              }))}
+              stackId="a"
+              showLegend={!isSingleUnnamedKind}
+              goalLines={goalLines}
+            />
+          ) : visibleKinds.length === 1 ? (
+            <ActivityChart
+              data={chartData}
+              dataKeys={[
+                {
+                  name: visibleKinds[0].name,
+                  color: kindColors[visibleKinds[0].name] || DEFAULT_BAR_COLOR,
+                },
+              ]}
+              showLegend={false}
+              goalLines={goalLines}
+            />
+          ) : (
+            <div className="space-y-4">
+              {visibleKinds.map((kind) => {
+                const kindData = allDates.map((date) => {
+                  const matchingLogs = kind.logs.filter(
+                    (l) => dayjs(l.date).format("YYYY-MM-DD") === date,
+                  );
+                  return {
+                    date: `${dayjs(date).date()}${t("dateLabel")}`,
+                    values: {
+                      [kind.name]: roundQuantity(
+                        matchingLogs.reduce((sum, l) => sum + l.quantity, 0),
+                      ),
+                    },
+                  };
+                });
+                return (
+                  <div key={kind.id || kind.name}>
+                    <h4 className="font-semibold text-sm mb-1 px-1">
+                      {kind.name}
+                      <span className="text-gray-400 font-normal ml-1">
+                        ({t("kindTotalLabel")}{" "}
+                        {formatQuantityWithUnit(kind.total, stat.quantityUnit)})
+                      </span>
+                    </h4>
+                    <ActivityChart
+                      data={kindData}
+                      dataKeys={[
+                        {
+                          name: kind.name,
+                          color: kindColors[kind.name] || DEFAULT_BAR_COLOR,
+                        },
+                      ]}
+                      height={220}
+                      showLegend={false}
+                      goalLines={goalLines}
+                    />
+                  </div>
                 );
-                return {
-                  date: `${dayjs(date).date()}${t("dateLabel")}`,
-                  values: {
-                    [kind.name]: roundQuantity(
-                      matchingLogs.reduce((sum, l) => sum + l.quantity, 0),
-                    ),
-                  },
-                };
-              });
-              return (
-                <div key={kind.id || kind.name}>
-                  <h4 className="font-semibold text-sm mb-1 px-1">
-                    {kind.name}
-                    <span className="text-gray-400 font-normal ml-1">
-                      ({t("kindTotalLabel")}{" "}
-                      {formatQuantityWithUnit(kind.total, stat.quantityUnit)})
-                    </span>
-                  </h4>
-                  <ActivityChart
-                    data={kindData}
-                    dataKeys={[
-                      {
-                        name: kind.name,
-                        color: kindColors[kind.name] || DEFAULT_BAR_COLOR,
-                      },
-                    ]}
-                    height={220}
-                    showLegend={false}
-                    goalLines={goalLines}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
+              })}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Summary */}
       <SummarySection summary={summary} quantityUnit={stat.quantityUnit} />

--- a/apps/mobile/src/components/stats/ActivityChartSection.tsx
+++ b/apps/mobile/src/components/stats/ActivityChartSection.tsx
@@ -1,3 +1,4 @@
+import { getVisibleKindsForCharts } from "@packages/frontend-shared/hooks/getVisibleKindsForCharts";
 import type {
   ActivityStat,
   ChartData,
@@ -32,11 +33,15 @@ export function ActivityChartSection({
   goalLines,
 }: ActivityChartSectionProps) {
   const { t } = useTranslation("stats");
+  const visibleKinds = getVisibleKindsForCharts(stat);
+
+  if (visibleKinds.length === 0) return null;
+
   if (stat.showCombinedStats) {
     return (
       <ActivityChart
         data={chartData}
-        dataKeys={stat.kinds.map((k) => ({
+        dataKeys={visibleKinds.map((k) => ({
           name: k.name,
           color: kindColors[k.name],
         }))}
@@ -47,14 +52,14 @@ export function ActivityChartSection({
     );
   }
 
-  if (stat.kinds.length === 1) {
+  if (visibleKinds.length === 1) {
     return (
       <ActivityChart
         data={chartData}
         dataKeys={[
           {
-            name: stat.kinds[0].name,
-            color: kindColors[stat.kinds[0].name] || DEFAULT_BAR_COLOR,
+            name: visibleKinds[0].name,
+            color: kindColors[visibleKinds[0].name] || DEFAULT_BAR_COLOR,
           },
         ]}
         showLegend={false}
@@ -65,7 +70,7 @@ export function ActivityChartSection({
 
   return (
     <View className="gap-4">
-      {stat.kinds.map((kind) => {
+      {visibleKinds.map((kind) => {
         const kindData = allDates.map((date) => {
           const matchingLogs = kind.logs.filter(
             (l) => dayjs(l.date).format("YYYY-MM-DD") === date,

--- a/apps/mobile/src/components/stats/ActivityStatCard.tsx
+++ b/apps/mobile/src/components/stats/ActivityStatCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 
+import { getVisibleKindsForCharts } from "@packages/frontend-shared/hooks/getVisibleKindsForCharts";
 import type {
   ActivityStat,
   ChartData,
@@ -84,6 +85,8 @@ export function ActivityStatCard({
   const isSingleUnnamedKind =
     stat.kinds.length === 1 && stat.kinds[0].name === t("defaultKind");
 
+  const hasVisibleChart = getVisibleKindsForCharts(stat).length > 0;
+
   return (
     <View className="border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden bg-gray-50 dark:bg-gray-800">
       {/* Activity header */}
@@ -140,16 +143,18 @@ export function ActivityStatCard({
       )}
 
       {/* Chart */}
-      <View className="p-4">
-        <ActivityChartSection
-          stat={stat}
-          chartData={chartData}
-          allDates={allDates}
-          kindColors={kindColors}
-          isSingleUnnamedKind={isSingleUnnamedKind}
-          goalLines={goalLines}
-        />
-      </View>
+      {hasVisibleChart && (
+        <View className="p-4">
+          <ActivityChartSection
+            stat={stat}
+            chartData={chartData}
+            allDates={allDates}
+            kindColors={kindColors}
+            isSingleUnnamedKind={isSingleUnnamedKind}
+            goalLines={goalLines}
+          />
+        </View>
+      )}
 
       {/* Summary */}
       <SummarySection summary={summary} quantityUnit={stat.quantityUnit} />

--- a/e2e/web/activity.test.ts
+++ b/e2e/web/activity.test.ts
@@ -95,11 +95,14 @@ describe("activity", () => {
     await page.click("button.border-red-300");
     await page.click("button.bg-red-600");
 
-    // ダイアログが閉じ、アクティビティが消える
+    // ダイアログが閉じ、アクティビティが消える（Dexie liveQuery の伝播を待つ）
     await page.waitForSelector(".modal-backdrop", {
       state: "detached",
       timeout: 15000,
     });
-    expect(await page.locator('text="削除対象活動"').isVisible()).toBe(false);
+    await page.waitForSelector('text="削除対象活動"', {
+      state: "detached",
+      timeout: 15000,
+    });
   });
 });

--- a/e2e/web/activity.test.ts
+++ b/e2e/web/activity.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, it } from "vitest";
 
 import { login } from "../helpers/auth";
 import { setupBrowser } from "../helpers/browser";

--- a/packages/frontend-shared/hooks/getVisibleKindsForCharts.test.ts
+++ b/packages/frontend-shared/hooks/getVisibleKindsForCharts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { getVisibleKindsForCharts } from "./getVisibleKindsForCharts";
+
+const makeKind = (
+  overrides: Partial<{
+    id: string | null;
+    name: string;
+    color: string | null;
+    total: number;
+    logs: { date: string; quantity: number }[];
+  }> & { name: string; total: number },
+) => ({
+  id: overrides.id ?? overrides.name,
+  color: overrides.color ?? null,
+  logs: overrides.logs ?? [],
+  ...overrides,
+});
+
+describe("getVisibleKindsForCharts", () => {
+  it("showCombinedStats=true の場合は total=0 のkindも含めて全て返す", () => {
+    const stat = {
+      showCombinedStats: true,
+      kinds: [
+        makeKind({ name: "朝", total: 5 }),
+        makeKind({ name: "夜", total: 0 }),
+      ],
+    };
+    const result = getVisibleKindsForCharts(stat);
+    expect(result).toHaveLength(2);
+    expect(result.map((k) => k.name)).toEqual(["朝", "夜"]);
+  });
+
+  it("showCombinedStats=false の場合は total=0 のkindを除外する", () => {
+    const stat = {
+      showCombinedStats: false,
+      kinds: [
+        makeKind({ name: "朝", total: 5 }),
+        makeKind({ name: "昼", total: 0 }),
+        makeKind({ name: "夜", total: 10 }),
+      ],
+    };
+    const result = getVisibleKindsForCharts(stat);
+    expect(result).toHaveLength(2);
+    expect(result.map((k) => k.name)).toEqual(["朝", "夜"]);
+  });
+
+  it("showCombinedStats=false で全kindがtotal=0の場合は空配列を返す", () => {
+    const stat = {
+      showCombinedStats: false,
+      kinds: [
+        makeKind({ name: "朝", total: 0 }),
+        makeKind({ name: "夜", total: 0 }),
+      ],
+    };
+    const result = getVisibleKindsForCharts(stat);
+    expect(result).toEqual([]);
+  });
+
+  it("showCombinedStats=false で全kindがtotal>0なら全て残る", () => {
+    const stat = {
+      showCombinedStats: false,
+      kinds: [
+        makeKind({ name: "朝", total: 3 }),
+        makeKind({ name: "夜", total: 7 }),
+      ],
+    };
+    const result = getVisibleKindsForCharts(stat);
+    expect(result).toHaveLength(2);
+  });
+
+  it("負の total は除外される（防御的）", () => {
+    const stat = {
+      showCombinedStats: false,
+      kinds: [
+        makeKind({ name: "朝", total: 5 }),
+        makeKind({ name: "謎", total: -1 }),
+      ],
+    };
+    const result = getVisibleKindsForCharts(stat);
+    expect(result.map((k) => k.name)).toEqual(["朝"]);
+  });
+});

--- a/packages/frontend-shared/hooks/getVisibleKindsForCharts.ts
+++ b/packages/frontend-shared/hooks/getVisibleKindsForCharts.ts
@@ -1,0 +1,8 @@
+import type { ActivityStat } from "../types/stats";
+
+export function getVisibleKindsForCharts(
+  stat: Pick<ActivityStat, "showCombinedStats" | "kinds">,
+): ActivityStat["kinds"] {
+  if (stat.showCombinedStats) return stat.kinds;
+  return stat.kinds.filter((k) => k.total > 0);
+}

--- a/packages/frontend-shared/hooks/index.ts
+++ b/packages/frontend-shared/hooks/index.ts
@@ -8,6 +8,7 @@ export {
   TUTORIAL_STEPS,
   createUseTutorial,
 } from "./createUseTutorial";
+export { getVisibleKindsForCharts } from "./getVisibleKindsForCharts";
 export type {
   ActivityBase,
   ActivityKindBase,


### PR DESCRIPTION
## Summary
- `showCombinedStats=false` のActivityで、当月の合計カウントが0の kind チャートをグラフ枠ごと非表示にする
- Web / Mobile 両方に適用（共通ヘルパー `getVisibleKindsForCharts` を `packages/frontend-shared` に新規追加）
- サマリーカード（小数値表示）と SummaryTable（折りたたみ表）は情報量を保つため変更なし
- `showCombinedStats=true`（積み上げグラフ）の挙動は不変

## 変更ファイル
- 新規: `packages/frontend-shared/hooks/getVisibleKindsForCharts.ts` + 5件のunit test
- Web: `apps/frontend/src/components/stats/ActivityStatCard.tsx`
- Mobile: `apps/mobile/src/components/stats/ActivityChartSection.tsx` / `ActivityStatCard.tsx`

## Test plan
- [x] `pnpm run test-once` (2063 passed)
- [x] `pnpm run tsc`
- [x] `pnpm run fix`
- [ ] 手動ブラウザ確認（マージャー側で実施推奨）
  - 合算統計オフ・複数kindのActivityを用意
  - 一部kindのみログがある月で /stats を開き、0カウントkindのチャートが非表示になることを確認
  - 全kindが0の月でチャート枠ごと消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)