### PR TITLE
fix(mobile/actiko): Activity編集ダイアログのstate初期化漏れを修正

### DIFF
--- a/apps/mobile/src/components/actiko/ActikoDialogs.tsx
+++ b/apps/mobile/src/components/actiko/ActikoDialogs.tsx
@@ -50,6 +50,7 @@ export function ActikoDialogs({
         onCreated={onActivityChanged}
       />
       <EditActivityDialog
+        key={editActivity?.id ?? "edit-closed"}
         visible={editActivity !== null}
         onClose={onEditClose}
         activity={editActivity}

--- a/apps/mobile/src/components/actiko/useEditActivityDialog.ts
+++ b/apps/mobile/src/components/actiko/useEditActivityDialog.ts
@@ -29,14 +29,20 @@ export function useEditActivityDialog(
   onClose: () => void,
 ) {
   const { kinds: existingKinds } = useActivityKinds(activity?.id);
-  const [name, setName] = useState("");
-  const [emoji, setEmoji] = useState("");
-  const [quantityUnit, setQuantityUnit] = useState("");
-  const [showCombinedStats, setShowCombinedStats] = useState(false);
+  const [name, setName] = useState(() => activity?.name ?? "");
+  const [emoji, setEmoji] = useState(() => activity?.emoji ?? "");
+  const [quantityUnit, setQuantityUnit] = useState(
+    () => activity?.quantityUnit ?? "",
+  );
+  const [showCombinedStats, setShowCombinedStats] = useState(
+    () => activity?.showCombinedStats ?? false,
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [recordingMode, setRecordingMode] = useState<RecordingMode>("manual");
+  const [recordingMode, setRecordingMode] = useState<RecordingMode>(
+    () => activity?.recordingMode ?? "manual",
+  );
   const [recordingModeConfig, setRecordingModeConfig] = useState<string | null>(
-    null,
+    () => activity?.recordingModeConfig ?? null,
   );
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [error, setError] = useState("");
@@ -50,19 +56,6 @@ export function useEditActivityDialog(
     updateKindName,
     updateKindColor,
   } = useActivityKindEntries();
-
-  useEffect(() => {
-    if (activity) {
-      setName(activity.name);
-      setEmoji(activity.emoji);
-      setQuantityUnit(activity.quantityUnit);
-      setShowCombinedStats(activity.showCombinedStats);
-      setRecordingMode(activity.recordingMode ?? "manual");
-      setRecordingModeConfig(activity.recordingModeConfig ?? null);
-      setShowDeleteConfirm(false);
-      setError("");
-    }
-  }, [activity]);
 
   useEffect(() => {
     if (existingKinds.length > 0) {


### PR DESCRIPTION
## Summary
直前にマージされた #216 でカウンターモードのステップ値反映漏れを `RecordingModeSelector` 内の useEffect 同期で対応したが、ローカル検証で「ステップ値がデフォルトのまま」になるケースが残った。

根本原因は `useEditActivityDialog` の state が空文字 / null / "manual" で初期化されていて、`useEffect([activity])` で後追い同期する設計だったため、子コンポーネントの最初のレンダリングは古い props を受け取っていた点。

## 修正内容
- `useEditActivityDialog`: `useState` の lazy initializer で activity から直接初期化し、後追い `useEffect` を削除
- `ActikoDialogs`: `<EditActivityDialog key={editActivity?.id ?? "edit-closed"} />` を付与し、activity 変更時に dialog 全体を remount
- これで子の `RecordingModeSelector` も最初のレンダリングから正しい `recordingModeConfig` を受け取り、`stepsText` の useState lazy init で正しい値が表示される

## Test plan
- [ ] カウンターモードで `[5, 25, 50]` のような非デフォルト値を保存した activity を編集ダイアログで開き、入力欄に `5, 25, 50` が表示されること
- [ ] 複数 activity を続けて編集して、それぞれ正しい値が表示されること（state がリークしない）
- [ ] 編集を保存せずに閉じて再度開いた時、DB の値で再表示されること
- [ ] mode 切替 → counter 復帰時に savedCounterConfig の挙動が変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)