### PR TITLE
fix(auth): セッション復旧とログアウト競合を修正

### DIFF
--- a/apps/frontend/src/auth/_webAuthTransportTestHelpers.ts
+++ b/apps/frontend/src/auth/_webAuthTransportTestHelpers.ts
@@ -13,17 +13,11 @@ export function createTokenHolder() {
   };
 }
 
-// vi.stubGlobal("fetch", ...) で global fetch を mock する前提で
-// authenticatedFetch も global fetch へデリゲート。logout のテストだけ
-// authenticatedFetch を直接 mock したいので opts で override 可能
 export function makeTransport(opts?: {
   tokenHolder?: ReturnType<typeof createTokenHolder>;
-  authenticatedFetch?: typeof fetch;
 }) {
-  const authenticatedFetch =
-    opts?.authenticatedFetch ?? ((input, init) => fetch(input, init));
   return createWebAuthTransport(
-    { apiUrl, authenticatedFetch },
+    { apiUrl },
     opts?.tokenHolder ?? createTokenHolder(),
   );
 }

--- a/apps/frontend/src/auth/authController.ts
+++ b/apps/frontend/src/auth/authController.ts
@@ -4,7 +4,7 @@ import {
 } from "@packages/auth-client";
 
 import { getApiUrl } from "../api/apiClient";
-import { customFetch, setRefreshAccessToken } from "../api/customFetch";
+import { setRefreshAccessToken } from "../api/customFetch";
 import { tokenHolder } from "../api/tokenHolder";
 import {
   clearStoredTabPreference,
@@ -16,12 +16,7 @@ import { clearLocalData, performInitialSync } from "../sync/initialSync";
 import { createWebAuthStateRepository } from "./webAuthStateRepository";
 import { createWebAuthTransport } from "./webAuthTransport";
 
-const transport = createWebAuthTransport(
-  { apiUrl: getApiUrl(), authenticatedFetch: customFetch },
-  tokenHolder,
-);
-
-setRefreshAccessToken(createRefreshAccessTokenCallback(transport));
+const transport = createWebAuthTransport({ apiUrl: getApiUrl() }, tokenHolder);
 
 export const authController = createAuthController({
   transport,
@@ -47,3 +42,10 @@ export const authController = createAuthController({
     queryClient.clear();
   },
 });
+
+setRefreshAccessToken(
+  createRefreshAccessTokenCallback(transport, {
+    getSessionVersion: () => authController.getSessionVersion(),
+    onExpired: () => authController.forceLogout(),
+  }),
+);

--- a/apps/frontend/src/auth/webAuthTransport.logout.test.ts
+++ b/apps/frontend/src/auth/webAuthTransport.logout.test.ts
@@ -9,8 +9,11 @@ vi.mock("@packages/sync-engine", () => ({
 
 import {
   apiUrl,
+  createTokenHolder,
   emptyResponse,
+  jsonResponse,
   makeTransport,
+  validSessionBody,
 } from "./_webAuthTransportTestHelpers";
 
 beforeEach(() => {
@@ -43,25 +46,77 @@ describe("webAuthTransport.logout", () => {
     expect(await transport.logout()).toEqual({ ok: false });
   });
 
-  it("authenticatedFetch 経由で /auth/logout を呼ぶ (Bearer 自動付与 + 401 retry を担う)", async () => {
-    // logout は authenticatedFetch を直接使うので、global fetch ではなく
-    // authenticatedFetch mock 自体に対する呼び出しを検証する
-    const authFetchMock = vi.fn().mockResolvedValue(emptyResponse(200));
-    const transport = makeTransport({ authenticatedFetch: authFetchMock });
+  it("401 後の refresh が expired なら server session 無効として { ok: true }", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(emptyResponse(401))
+      .mockResolvedValueOnce(emptyResponse(401));
+    vi.stubGlobal("fetch", fetchMock);
 
-    const result = await transport.logout();
-
-    expect(result).toEqual({ ok: true });
-    expect(authFetchMock).toHaveBeenCalledWith(
-      `${apiUrl}/auth/logout`,
-      expect.objectContaining({ method: "POST" }),
-    );
+    expect(await makeTransport().logout()).toEqual({ ok: true });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(`${apiUrl}/auth/logout`);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(`${apiUrl}/auth/token`);
   });
 
-  it("authenticatedFetch が 401 を返すと { ok: false } (内部で refresh retry も尽きた場合)", async () => {
-    const authFetchMock = vi.fn().mockResolvedValue(emptyResponse(401));
-    const transport = makeTransport({ authenticatedFetch: authFetchMock });
+  it("401 後の refresh が transient なら credential を保持して { ok: false }", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(emptyResponse(401))
+        .mockResolvedValueOnce(emptyResponse(503)),
+    );
 
-    expect(await transport.logout()).toEqual({ ok: false });
+    expect(await makeTransport().logout()).toEqual({ ok: false });
+  });
+
+  it("401 後の refresh 成功時は新しい Bearer で logout を再送する", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(emptyResponse(401))
+      .mockResolvedValueOnce(jsonResponse(validSessionBody("jwt-new")))
+      .mockResolvedValueOnce(emptyResponse(200));
+    vi.stubGlobal("fetch", fetchMock);
+    const tokenHolder = createTokenHolder();
+    tokenHolder.setToken("jwt-old");
+    const transport = makeTransport({ tokenHolder });
+
+    expect(await transport.logout()).toEqual({ ok: true });
+
+    const retryHeaders = new Headers(fetchMock.mock.calls[2]?.[1]?.headers);
+    expect(retryHeaders.get("Authorization")).toBe("Bearer jwt-new");
+  });
+
+  it("進行中 login の cookie 応答後に logout を実行して新 session を残さない", async () => {
+    let resolveLogin!: (response: Response) => void;
+    const loginResponse = new Promise<Response>((resolve) => {
+      resolveLogin = resolve;
+    });
+    let logoutCalls = 0;
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/auth/login")) return loginResponse;
+      if (url.endsWith("/auth/token")) {
+        return Promise.resolve(jsonResponse(validSessionBody("jwt-new")));
+      }
+      logoutCalls++;
+      return Promise.resolve(emptyResponse(logoutCalls === 1 ? 401 : 200));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const transport = makeTransport();
+
+    const login = transport.login("user", "pw");
+    const logout = transport.logout();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveLogin(jsonResponse(validSessionBody("jwt-login")));
+    await Promise.all([login, logout]);
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      `${apiUrl}/auth/login`,
+      `${apiUrl}/auth/logout`,
+      `${apiUrl}/auth/token`,
+      `${apiUrl}/auth/logout`,
+    ]);
   });
 });

--- a/apps/frontend/src/auth/webAuthTransport.test.ts
+++ b/apps/frontend/src/auth/webAuthTransport.test.ts
@@ -75,6 +75,15 @@ describe("webAuthTransport", () => {
       const result = await transport.refreshSession();
       expect(result.kind).toBe("transient");
     });
+
+    it("429 -> { kind: 'transient' } (rate limit はセッション失効ではない)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(emptyResponse(429)));
+      const transport = makeTransport();
+
+      const result = await transport.refreshSession();
+
+      expect(result.kind).toBe("transient");
+    });
   });
 
   describe("login", () => {
@@ -87,6 +96,30 @@ describe("webAuthTransport", () => {
 
       const session = await transport.login("user", "pw");
       expect(session.token).toBe("login-jwt");
+    });
+
+    it("進行中 refresh の完了後に login を送り、古い cookie 応答の後に新規 session を確立する", async () => {
+      let resolveRefresh!: (response: Response) => void;
+      const refreshResponse = new Promise<Response>((resolve) => {
+        resolveRefresh = resolve;
+      });
+      const fetchMock = vi.fn((url: string) => {
+        if (url.endsWith("/auth/token")) return refreshResponse;
+        return Promise.resolve(jsonResponse(validSessionBody("login-jwt")));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const transport = makeTransport();
+
+      const refresh = transport.refreshSession();
+      const login = transport.login("user", "pw");
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      resolveRefresh(jsonResponse(validSessionBody("refreshed-jwt")));
+      await Promise.all([refresh, login]);
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(`${apiUrl}/auth/token`);
+      expect(fetchMock.mock.calls[1]?.[0]).toBe(`${apiUrl}/auth/login`);
     });
 
     it("401 -> invalidCredentials エラー", async () => {

--- a/apps/frontend/src/auth/webAuthTransport.ts
+++ b/apps/frontend/src/auth/webAuthTransport.ts
@@ -3,6 +3,10 @@ import type {
   AuthTransport,
   RefreshResult,
 } from "@packages/auth-client";
+import {
+  classifyRefreshFailure,
+  newAuthOperationCoordinator,
+} from "@packages/auth-client";
 import { i18next } from "@packages/i18n";
 import { trackServerTimeFromResponse } from "@packages/sync-engine";
 import type { Consents } from "@packages/types/request";
@@ -10,10 +14,6 @@ import { authResponseSchema } from "@packages/types/response";
 
 type TransportOptions = {
   apiUrl: string;
-  // 401 retry + Bearer 自動付与つき fetch (createAuthenticatedFetch 経由)。
-  // logout は authMiddleware が Bearer 必須なので、access token 期限切れ時に
-  // 自動 refresh + retry されないと「永久に 401 で詰む」状態になる
-  authenticatedFetch: typeof fetch;
 };
 
 type TokenHolder = {
@@ -26,7 +26,9 @@ export function createWebAuthTransport(
   tokenHolder: TokenHolder,
 ): AuthTransport {
   const apiUrl = options.apiUrl.replace(/\/+$/, "");
-  const authenticatedFetch = options.authenticatedFetch;
+  const coordinator = newAuthOperationCoordinator<RefreshResult>(() =>
+    runRefreshSession(),
+  );
 
   const parseSession = async (res: Response): Promise<AuthSession> => {
     return authResponseSchema.parse(await res.json());
@@ -44,71 +46,93 @@ export function createWebAuthTransport(
     });
   };
 
+  const runRefreshSession = async (): Promise<RefreshResult> => {
+    const res = await postAuth("/auth/token", undefined);
+    trackServerTimeFromResponse(res);
+    if (res.ok) return { kind: "ok", session: await parseSession(res) };
+    return classifyRefreshFailure(res.status);
+  };
+
+  const postLogout = (): Promise<Response> => {
+    const accessToken = tokenHolder.getToken();
+    return fetch(`${apiUrl}/auth/logout`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      },
+      credentials: "include",
+    });
+  };
+
+  const performLogout = async (
+    refreshDuringLogout: () => Promise<RefreshResult>,
+  ): Promise<{ ok: boolean }> => {
+    try {
+      let res = await postLogout();
+      if (res.status !== 401) return { ok: res.ok };
+      const refreshResult = await refreshDuringLogout();
+      if (refreshResult.kind === "expired") return { ok: true };
+      if (refreshResult.kind === "transient") return { ok: false };
+      tokenHolder.setToken(refreshResult.session.token);
+      res = await postLogout();
+      return { ok: res.ok };
+    } catch {
+      return { ok: false };
+    }
+  };
+
   return {
     async login(loginId, password) {
-      let res: Response;
-      try {
-        res = await postAuth("/auth/login", { login_id: loginId, password });
-        trackServerTimeFromResponse(res);
-      } catch {
-        throw new Error(i18next.t("common:api.networkError"));
-      }
-      if (!res.ok) {
-        if (res.status === 401)
-          throw new Error(i18next.t("common:api.invalidCredentials"));
-        if (res.status >= 500)
-          throw new Error(i18next.t("common:api.serverError"));
-        throw new Error(i18next.t("common:api.loginError"));
-      }
-      return parseSession(res);
+      return coordinator.runSessionOperation(async () => {
+        let res: Response;
+        try {
+          res = await postAuth("/auth/login", { login_id: loginId, password });
+          trackServerTimeFromResponse(res);
+        } catch {
+          throw new Error(i18next.t("common:api.networkError"));
+        }
+        if (!res.ok) {
+          if (res.status === 401)
+            throw new Error(i18next.t("common:api.invalidCredentials"));
+          if (res.status >= 500)
+            throw new Error(i18next.t("common:api.serverError"));
+          throw new Error(i18next.t("common:api.loginError"));
+        }
+        return parseSession(res);
+      });
     },
     async register(loginId, password, consents) {
-      const res = await postAuth("/user", { loginId, password, consents });
-      if (!res.ok) throw new Error("Registration failed");
-      return parseSession(res);
+      return coordinator.runSessionOperation(async () => {
+        const res = await postAuth("/user", { loginId, password, consents });
+        if (!res.ok) throw new Error("Registration failed");
+        return parseSession(res);
+      });
     },
     async googleLogin(credential, consents?: Consents) {
-      const res = await postAuth("/auth/google", { credential, consents });
-      if (!res.ok) throw new Error("Google login failed");
-      return parseSession(res);
+      return coordinator.runSessionOperation(async () => {
+        const res = await postAuth("/auth/google", { credential, consents });
+        if (!res.ok) throw new Error("Google login failed");
+        return parseSession(res);
+      });
     },
     async appleLogin(credential, consents?: Consents) {
-      const res = await postAuth("/auth/apple", { credential, consents });
-      if (!res.ok) throw new Error("Apple login failed");
-      return parseSession(res);
+      return coordinator.runSessionOperation(async () => {
+        const res = await postAuth("/auth/apple", { credential, consents });
+        if (!res.ok) throw new Error("Apple login failed");
+        return parseSession(res);
+      });
     },
-    async refreshSession(): Promise<RefreshResult> {
-      const res = await postAuth("/auth/token", undefined);
-      trackServerTimeFromResponse(res);
-      if (res.ok) return { kind: "ok", session: await parseSession(res) };
-      // 401/403 等: セッション復元不能。500 系: 一時障害でリトライ可能
-      if (res.status < 500) return { kind: "expired" };
-      return { kind: "transient", reason: `status ${res.status}` };
-    },
-    async logout() {
-      // /auth/logout は authMiddleware が Bearer 必須。authenticatedFetch は
-      // Bearer 自動付与 + 401 retry (refresh → 新 token で再送) を担う。
-      // これがないと access token 期限切れ後の logout が永久に 401 で詰まる
-      try {
-        const res = await authenticatedFetch(`${apiUrl}/auth/logout`, {
-          method: "POST",
-        });
-        // 200 系のみ成功扱い。失敗時は httpOnly cookie が残るため UI 警告対象
-        return { ok: res.ok };
-      } catch {
-        return { ok: false };
-      }
-    },
+    refreshSession: coordinator.refreshSession,
+    logout: () => coordinator.runSessionOperation(performLogout),
     setAccessToken(token) {
       tokenHolder.setToken(token);
     },
     async persistSession() {
-      // Web は backend が Set-Cookie で refresh_token を反映するため永続層への書き込みは不要。
-      // access token のメモリ反映は setAccessToken の専任。
+      await coordinator.runSessionOperation(async () => {});
     },
     async clearPersistedSession() {
-      // Web の refresh_token は httpOnly cookie なので JS から削除不能。delete
-      // account 経路では backend で revoke + expire 済みのため no-op で問題ない
+      await coordinator.runSessionOperation(async () => {});
     },
   };
 }

--- a/apps/mobile/src/auth/authController.ts
+++ b/apps/mobile/src/auth/authController.ts
@@ -22,15 +22,21 @@ const transport = createMobileAuthTransport(
   tokenHolder,
 );
 
-setRefreshAccessToken(createRefreshAccessTokenCallback(transport));
-
 export const authController = createAuthController({
   transport,
   authStateRepo: createMobileAuthStateRepository(),
   online: {
     registerOnlineRetry(handler) {
+      let previousConnected: boolean | null = null;
       const unsub = NetInfo.addEventListener((info) => {
-        if (info.isConnected) handler();
+        const connected = info.isConnected === true;
+        if (previousConnected === null) {
+          previousConnected = connected;
+          return;
+        }
+        const recovered = !previousConnected && connected;
+        previousConnected = connected;
+        if (recovered) handler();
       });
       return unsub;
     },
@@ -52,3 +58,10 @@ export const authController = createAuthController({
     void clearStoredTabPreference();
   },
 });
+
+setRefreshAccessToken(
+  createRefreshAccessTokenCallback(transport, {
+    getSessionVersion: () => authController.getSessionVersion(),
+    onExpired: () => authController.forceLogout(),
+  }),
+);

--- a/apps/mobile/src/auth/mobileAuthTransport.flows.test.ts
+++ b/apps/mobile/src/auth/mobileAuthTransport.flows.test.ts
@@ -66,6 +66,50 @@ describe("mobileAuthTransport.login", () => {
     expect(mockSetItem).toHaveBeenCalledWith(REFRESH_TOKEN_KEY, "rt");
   });
 
+  it("進行中 refresh の永続化後に login を送り、新しい refresh token を最後に保存する", async () => {
+    mockGetItem.mockResolvedValue("rt-old");
+    let resolveRefresh!: (response: Response) => void;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/auth/token")) return refreshResponse;
+      return Promise.resolve(
+        jsonResponse(
+          validSessionBody({ token: "jwt-login", refreshToken: "rt-login" }),
+        ),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const transport = makeTransport();
+
+    const refresh = transport.refreshSession();
+    const login = transport.login("u", "pw");
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveRefresh(
+      jsonResponse(
+        validSessionBody({
+          token: "jwt-refreshed",
+          refreshToken: "rt-refreshed",
+        }),
+      ),
+    );
+    await Promise.all([refresh, login]);
+
+    expect(mockSetItem).toHaveBeenNthCalledWith(
+      1,
+      REFRESH_TOKEN_KEY,
+      "rt-refreshed",
+    );
+    expect(mockSetItem).toHaveBeenNthCalledWith(
+      2,
+      REFRESH_TOKEN_KEY,
+      "rt-login",
+    );
+  });
+
   it("401 -> invalidCredentials", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(emptyResponse(401)));
 

--- a/apps/mobile/src/auth/mobileAuthTransport.logout.test.ts
+++ b/apps/mobile/src/auth/mobileAuthTransport.logout.test.ts
@@ -19,6 +19,7 @@ import * as SecureStore from "expo-secure-store";
 
 import {
   REFRESH_TOKEN_KEY,
+  apiUrl,
   createTokenHolder,
   emptyResponse,
   jsonResponse,
@@ -81,6 +82,166 @@ describe("mobileAuthTransport.logout", () => {
 
     expect(result).toEqual({ ok: false });
     expect(mockDeleteItem).not.toHaveBeenCalled();
+  });
+
+  it("進行中の通常 refresh を待ってから logout し、遅延応答で credential を復活させない", async () => {
+    let storedRefreshToken: string | null = "rt-old";
+    mockGetItem.mockImplementation(async () => storedRefreshToken);
+    mockSetItem.mockImplementation(async (_key: string, value: string) => {
+      storedRefreshToken = value;
+    });
+    mockDeleteItem.mockImplementation(async () => {
+      storedRefreshToken = null;
+    });
+
+    let resolveRefresh!: (response: Response) => void;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/auth/token")) return refreshResponse;
+      return Promise.resolve(emptyResponse(200));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tokenHolder = createTokenHolder();
+    tokenHolder.setToken("jwt-old");
+    const transport = makeTransport({ tokenHolder });
+
+    const apiRefresh = (async () => {
+      const result = await transport.refreshSession();
+      if (result.kind === "ok") {
+        transport.setAccessToken(result.session.token);
+      }
+    })();
+    const controllerLogout = (async () => {
+      const result = await transport.logout();
+      if (result.ok) transport.setAccessToken(null);
+      return result;
+    })();
+
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+    resolveRefresh(
+      jsonResponse(
+        validSessionBody({
+          token: "jwt-late",
+          refreshToken: "rt-late",
+        }),
+      ),
+    );
+
+    const [, logoutResult] = await Promise.all([apiRefresh, controllerLogout]);
+
+    expect(logoutResult).toEqual({ ok: true });
+    expect(storedRefreshToken).toBeNull();
+    expect(tokenHolder.getToken()).toBeNull();
+  });
+
+  it("進行中 login の永続化後に logout し、遅延 login credential を残さない", async () => {
+    let storedRefreshToken: string | null = "rt-old";
+    mockGetItem.mockImplementation(async () => storedRefreshToken);
+    mockSetItem.mockImplementation(async (_key: string, value: string) => {
+      storedRefreshToken = value;
+    });
+    mockDeleteItem.mockImplementation(async () => {
+      storedRefreshToken = null;
+    });
+    let resolveLogin!: (response: Response) => void;
+    const loginResponse = new Promise<Response>((resolve) => {
+      resolveLogin = resolve;
+    });
+    let logoutCalls = 0;
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/auth/login")) return loginResponse;
+      if (url.endsWith("/auth/token")) {
+        return Promise.resolve(
+          jsonResponse(
+            validSessionBody({
+              token: "jwt-refreshed",
+              refreshToken: "rt-refreshed",
+            }),
+          ),
+        );
+      }
+      logoutCalls++;
+      return Promise.resolve(emptyResponse(logoutCalls === 1 ? 401 : 200));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const transport = makeTransport();
+
+    const login = transport.login("u", "pw");
+    const logout = transport.logout();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveLogin(
+      jsonResponse(
+        validSessionBody({ token: "jwt-login", refreshToken: "rt-login" }),
+      ),
+    );
+    await Promise.all([login, logout]);
+
+    expect(storedRefreshToken).toBeNull();
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      `${apiUrl}/auth/login`,
+      `${apiUrl}/auth/logout`,
+      `${apiUrl}/auth/token`,
+      `${apiUrl}/auth/logout`,
+    ]);
+  });
+
+  it("logout 成功を待つ新規 refresh は token endpoint を呼ばず expired になる", async () => {
+    let storedRefreshToken: string | null = "rt";
+    mockGetItem.mockImplementation(async () => storedRefreshToken);
+    mockDeleteItem.mockImplementation(async () => {
+      storedRefreshToken = null;
+    });
+    let resolveLogout!: (response: Response) => void;
+    const logoutResponse = new Promise<Response>((resolve) => {
+      resolveLogout = resolve;
+    });
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/auth/logout")) return logoutResponse;
+      return Promise.resolve(jsonResponse(validSessionBody()));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const transport = makeTransport();
+
+    const logout = transport.logout();
+    const refresh = transport.refreshSession();
+    resolveLogout(emptyResponse(200));
+
+    await expect(logout).resolves.toEqual({ ok: true });
+    await expect(refresh).resolves.toEqual({ kind: "expired" });
+    expect(
+      fetchMock.mock.calls.some(([url]) => String(url).endsWith("/auth/token")),
+    ).toBe(false);
+  });
+
+  it("logout 失敗を待つ新規 refresh は保持した token で回復を再開する", async () => {
+    mockGetItem.mockResolvedValue("rt");
+    let resolveLogout!: (response: Response) => void;
+    const logoutResponse = new Promise<Response>((resolve) => {
+      resolveLogout = resolve;
+    });
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/auth/logout")) return logoutResponse;
+      return Promise.resolve(
+        jsonResponse(
+          validSessionBody({ token: "jwt-new", refreshToken: "rt-new" }),
+        ),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const transport = makeTransport();
+
+    const logout = transport.logout();
+    const refresh = transport.refreshSession();
+    resolveLogout(emptyResponse(503));
+
+    await expect(logout).resolves.toEqual({ ok: false });
+    await expect(refresh).resolves.toMatchObject({ kind: "ok" });
+    expect(mockSetItem).toHaveBeenCalledWith(REFRESH_TOKEN_KEY, "rt-new");
   });
 
   it("401 -> refreshSession で refresh token を rotate → 新 X-Refresh-Token で retry して成功", async () => {

--- a/apps/mobile/src/auth/mobileAuthTransport.test.ts
+++ b/apps/mobile/src/auth/mobileAuthTransport.test.ts
@@ -105,6 +105,16 @@ describe("mobileAuthTransport.refreshSession", () => {
     expect(mockDeleteItem).not.toHaveBeenCalled();
   });
 
+  it("429 -> { kind: 'transient' } + refresh token を保持する", async () => {
+    mockGetItem.mockResolvedValue("rt");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(emptyResponse(429)));
+
+    const result = await makeTransport().refreshSession();
+
+    expect(result.kind).toBe("transient");
+    expect(mockDeleteItem).not.toHaveBeenCalled();
+  });
+
   it("network error -> { kind: 'transient' }", async () => {
     mockGetItem.mockResolvedValue("rt");
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("network")));

--- a/apps/mobile/src/auth/mobileAuthTransport.ts
+++ b/apps/mobile/src/auth/mobileAuthTransport.ts
@@ -3,6 +3,10 @@ import type {
   AuthTransport,
   RefreshResult,
 } from "@packages/auth-client";
+import {
+  classifyRefreshFailure,
+  newAuthOperationCoordinator,
+} from "@packages/auth-client";
 import { i18next } from "@packages/i18n";
 import { trackServerTimeFromResponse } from "@packages/sync-engine";
 import type { Consents } from "@packages/types/request";
@@ -31,7 +35,6 @@ type TokenHolder = {
 };
 
 type ErrorMessages = {
-  // 401 受信時に特殊扱いするキー (login のみ「ID/パスワード違い」を出すため)
   invalidCredentials?: string;
   generic: string;
 };
@@ -41,10 +44,10 @@ export function createMobileAuthTransport(
   tokenHolder: TokenHolder,
 ): AuthTransport {
   const apiUrl = options.apiUrl.replace(/\/+$/, "");
+  const coordinator = newAuthOperationCoordinator<RefreshResult>(() =>
+    runRefreshSession(),
+  );
 
-  // login/register/oauth レスポンスから session を取り出す内部 helper。
-  // access token のメモリ反映は controller.applySession 内の transport.setAccessToken
-  // の専任なのでここでは呼ばない。refresh token のみ永続層に書き込む。
   const persistSession = async (res: Response): Promise<AuthSession> => {
     const session = authResponseSchema.parse(await res.json());
     if (session.refreshToken) await setStoredRefreshToken(session.refreshToken);
@@ -77,7 +80,7 @@ export function createMobileAuthTransport(
     return persistSession(res);
   };
 
-  const refreshSession = async (): Promise<RefreshResult> => {
+  const runRefreshSession = async (): Promise<RefreshResult> => {
     const rt = await getStoredRefreshToken();
     if (!rt) return { kind: "expired" };
     let res: Response;
@@ -94,16 +97,13 @@ export function createMobileAuthTransport(
       return { kind: "transient", reason: "network" };
     }
     if (res.ok) return { kind: "ok", session: await persistSession(res) };
-    if (res.status < 500) {
+    const failure = classifyRefreshFailure(res.status);
+    if (failure.kind === "expired") {
       await clearStoredRefreshToken();
-      return { kind: "expired" };
     }
-    return { kind: "transient", reason: `status ${res.status}` };
+    return failure;
   };
 
-  // /auth/logout を access + refresh token 付きで送る。retry でも token を
-  // 再取得するため引数化 (refresh token は rotation で更新されるため
-  // SecureStore から再度読み直す必要がある)
   const postLogout = async (): Promise<Response> => {
     const accessToken = tokenHolder.getToken();
     const refreshToken = await getStoredRefreshToken();
@@ -117,82 +117,84 @@ export function createMobileAuthTransport(
     });
   };
 
+  const performLogout = async (
+    refreshDuringLogout: () => Promise<RefreshResult>,
+  ): Promise<{ ok: boolean }> => {
+    let serverOk = false;
+    try {
+      let res = await postLogout();
+      if (res.status === 401) {
+        const refreshResult = await refreshDuringLogout();
+        if (refreshResult.kind === "ok") {
+          tokenHolder.setToken(refreshResult.session.token);
+          res = await postLogout();
+          serverOk = res.ok;
+        } else if (refreshResult.kind === "expired") {
+          serverOk = true;
+        }
+      } else {
+        serverOk = res.ok;
+      }
+    } catch {
+      // credential を保持し、logout を再試行可能にする。
+    }
+    if (serverOk) {
+      await clearStoredRefreshToken();
+    }
+    return { ok: serverOk };
+  };
+
   return {
     login: (loginId, password) =>
-      postAuthAndParse(
-        "/auth/login",
-        { login_id: loginId, password },
-        {
-          invalidCredentials: i18next.t("common:api.invalidCredentials"),
-          generic: i18next.t("common:auth.loginError"),
-        },
+      coordinator.runSessionOperation(() =>
+        postAuthAndParse(
+          "/auth/login",
+          { login_id: loginId, password },
+          {
+            invalidCredentials: i18next.t("common:api.invalidCredentials"),
+            generic: i18next.t("common:auth.loginError"),
+          },
+        ),
       ),
     register: (loginId, password, consents) =>
-      postAuthAndParse(
-        "/user",
-        { loginId, password, consents },
-        { generic: i18next.t("common:auth.registerError") },
+      coordinator.runSessionOperation(() =>
+        postAuthAndParse(
+          "/user",
+          { loginId, password, consents },
+          { generic: i18next.t("common:auth.registerError") },
+        ),
       ),
     googleLogin: (credential, consents?: Consents) =>
-      postAuthAndParse(
-        "/auth/google",
-        { credential, consents },
-        { generic: i18next.t("common:auth.googleLoginError") },
+      coordinator.runSessionOperation(() =>
+        postAuthAndParse(
+          "/auth/google",
+          { credential, consents },
+          { generic: i18next.t("common:auth.googleLoginError") },
+        ),
       ),
     appleLogin: (credential, consents?: Consents) =>
-      postAuthAndParse(
-        "/auth/apple",
-        { credential, consents },
-        { generic: i18next.t("common:auth.appleLoginError") },
+      coordinator.runSessionOperation(() =>
+        postAuthAndParse(
+          "/auth/apple",
+          { credential, consents },
+          { generic: i18next.t("common:auth.appleLoginError") },
+        ),
       ),
-    refreshSession,
-    async logout() {
-      // /auth/logout は authMiddleware が Bearer 必須なため、現在の access token を
-      // 付与する。401 retry は自前実装: refreshSession が refresh token を rotate
-      // するので SecureStore を読み直して新 X-Refresh-Token を送る (createAuthenticatedFetch
-      // 経由だと Authorization のみ更新されて X-Refresh-Token は古い値で再送される)
-      let serverOk = false;
-      try {
-        let res = await postLogout();
-        if (res.status === 401) {
-          const refreshResult = await refreshSession();
-          if (refreshResult.kind === "ok") {
-            tokenHolder.setToken(refreshResult.session.token);
-            res = await postLogout();
-            serverOk = res.ok;
-          } else if (refreshResult.kind === "expired") {
-            // refresh も拒否された = backend 側にもう session が無い (= 既にログアウト
-            // 達成済みと等価)。SecureStore は refreshSession の expired 分岐が既に
-            // 消しているので、ここで ok 扱いにして controller の resetAuthState を
-            // 呼ばせる (放置すると local state 残存 + SecureStore 空で再試行不能になる)
-            serverOk = true;
-          }
-          // transient (5xx 等) は serverOk=false のまま → 再試行可
-        } else {
-          serverOk = res.ok;
-        }
-      } catch {
-        // network error / timeout など。SecureStore を消さず再試行可能にする
-      }
-      // server 成功時のみ SecureStore を clear する。失敗時に消すと
-      // X-Refresh-Token を再送できず logout 再試行が永久に通らなくなる
-      // (controller 側も { ok: false } 時は local state を保持する)
-      if (serverOk) {
-        await clearStoredRefreshToken();
-      }
-      return { ok: serverOk };
-    },
+    refreshSession: coordinator.refreshSession,
+    logout: () => coordinator.runSessionOperation(performLogout),
     setAccessToken(token) {
       tokenHolder.setToken(token);
     },
     async persistSession(session) {
-      // 永続層 (SecureStore) への書き込みのみ。access token のメモリ反映は
-      // setAccessToken の専任。
-      if (session.refreshToken)
-        await setStoredRefreshToken(session.refreshToken);
+      await coordinator.runSessionOperation(async () => {
+        if (session.refreshToken)
+          await setStoredRefreshToken(session.refreshToken);
+      });
     },
     async clearPersistedSession() {
-      await clearStoredRefreshToken();
+      await coordinator.runSessionOperation(async () => {
+        await clearStoredRefreshToken();
+      });
     },
   };
 }

--- a/packages/auth-client/authOperationCoordinator.test.ts
+++ b/packages/auth-client/authOperationCoordinator.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { newAuthOperationCoordinator } from "./authOperationCoordinator";
+
+describe("newAuthOperationCoordinator", () => {
+  it("session operation 中に始まった refresh を後ろへ直列化する", async () => {
+    let resolveLogin!: () => void;
+    const loginGate = new Promise<void>((resolve) => {
+      resolveLogin = resolve;
+    });
+    const runRefresh = vi.fn(async () => "refreshed");
+    const coordinator = newAuthOperationCoordinator(runRefresh);
+    const order: string[] = [];
+
+    const login = coordinator.runSessionOperation(async () => {
+      order.push("login:start");
+      await loginGate;
+      order.push("login:end");
+      return "logged-in";
+    });
+    const refresh = coordinator.refreshSession();
+    await Promise.resolve();
+
+    expect(runRefresh).not.toHaveBeenCalled();
+    resolveLogin();
+    await Promise.all([login, refresh]);
+
+    expect(order).toEqual(["login:start", "login:end"]);
+    expect(runRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("同時 refresh は単一の operation を共有する", async () => {
+    const runRefresh = vi.fn(async () => "refreshed");
+    const coordinator = newAuthOperationCoordinator(runRefresh);
+
+    const [first, second] = await Promise.all([
+      coordinator.refreshSession(),
+      coordinator.refreshSession(),
+    ]);
+
+    expect(first).toBe("refreshed");
+    expect(second).toBe("refreshed");
+    expect(runRefresh).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/auth-client/authOperationCoordinator.ts
+++ b/packages/auth-client/authOperationCoordinator.ts
@@ -1,0 +1,32 @@
+export function newAuthOperationCoordinator<TRefresh>(
+  runRefresh: () => Promise<TRefresh>,
+) {
+  let operationTail = Promise.resolve();
+  let refreshPromise: Promise<TRefresh> | null = null;
+
+  const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
+    const pending = operationTail.then(operation, operation);
+    operationTail = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    return pending;
+  };
+
+  const refreshSession = (): Promise<TRefresh> => {
+    if (refreshPromise) return refreshPromise;
+    const pending = enqueue(runRefresh);
+    refreshPromise = pending;
+    const clearPending = () => {
+      if (refreshPromise === pending) refreshPromise = null;
+    };
+    void pending.then(clearPending, clearPending);
+    return pending;
+  };
+
+  const runSessionOperation = <T>(
+    operation: (refreshWithinOperation: () => Promise<TRefresh>) => Promise<T>,
+  ): Promise<T> => enqueue(() => operation(runRefresh));
+
+  return { refreshSession, runSessionOperation };
+}

--- a/packages/auth-client/authRetryScheduler.ts
+++ b/packages/auth-client/authRetryScheduler.ts
@@ -1,0 +1,45 @@
+import type { OnlineRetryAdapter } from "./types";
+
+const BASE_DELAY_MS = 1_000;
+const MAX_DELAY_MS = 30_000;
+
+export function newAuthRetryScheduler(online?: OnlineRetryAdapter) {
+  let onlineCleanup: (() => void) | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let retryAttempt = 0;
+
+  const clear = () => {
+    if (onlineCleanup) {
+      onlineCleanup();
+      onlineCleanup = null;
+    }
+    if (retryTimer !== null) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+  };
+
+  const reset = () => {
+    clear();
+    retryAttempt = 0;
+  };
+
+  const schedule = (handler: () => void) => {
+    clear();
+    const delay = Math.min(BASE_DELAY_MS * 2 ** retryAttempt, MAX_DELAY_MS);
+    retryAttempt++;
+    let armed = false;
+    const retry = () => {
+      // NetInfo は購読直後に現在値を通知し得る。登録完了前の snapshot は無視する。
+      if (!armed) return;
+      clear();
+      handler();
+    };
+
+    retryTimer = setTimeout(retry, delay);
+    if (online) onlineCleanup = online.registerOnlineRetry(retry);
+    armed = true;
+  };
+
+  return { clear, reset, schedule };
+}

--- a/packages/auth-client/classifyRefreshFailure.ts
+++ b/packages/auth-client/classifyRefreshFailure.ts
@@ -1,0 +1,10 @@
+import type { RefreshResult } from "./types";
+
+type RefreshFailure = Exclude<RefreshResult, { kind: "ok" }>;
+
+export function classifyRefreshFailure(status: number): RefreshFailure {
+  if (status === 400 || status === 401 || status === 403) {
+    return { kind: "expired" };
+  }
+  return { kind: "transient", reason: `status ${status}` };
+}

--- a/packages/auth-client/createAuthController.test.ts
+++ b/packages/auth-client/createAuthController.test.ts
@@ -270,6 +270,104 @@ describe("createAuthController", () => {
     expect(controller.getState().isLoggedIn).toBe(true);
   });
 
+  it("initial sync failure keeps the authenticated state and retries until syncReady", async () => {
+    const transport = makeTransport({
+      refreshResults: [
+        { kind: "ok", session: makeSession("u1") },
+        { kind: "ok", session: makeSession("u1") },
+      ],
+    });
+    const initialSync = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("sync unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const handlerRef: { current: (() => void) | null } = { current: null };
+    const controller = createAuthController({
+      transport,
+      authStateRepo: makeRepo(),
+      performInitialSync: initialSync,
+      online: {
+        registerOnlineRetry(handler) {
+          handlerRef.current = handler;
+          return () => {
+            handlerRef.current = null;
+          };
+        },
+      },
+    });
+
+    await expect(controller.reconcile()).resolves.toBe(false);
+    expect(controller.getState()).toMatchObject({
+      isLoggedIn: true,
+      userId: "u1",
+      syncReady: false,
+    });
+    expect(handlerRef.current).not.toBeNull();
+
+    handlerRef.current?.();
+    await vi.waitFor(() => {
+      expect(initialSync).toHaveBeenCalledTimes(2);
+      expect(controller.getState().syncReady).toBe(true);
+    });
+  });
+
+  it("ignores an adapter's synchronous connectivity snapshot to avoid a refresh storm", async () => {
+    const transport = makeTransport({
+      refreshResults: [
+        { kind: "transient", reason: "status 503" },
+        { kind: "ok", session: makeSession("u1") },
+      ],
+    });
+    const refreshSpy = vi.spyOn(transport, "refreshSession");
+    const cleanup = vi.fn();
+    const controller = createAuthController({
+      transport,
+      authStateRepo: makeRepo(),
+      performInitialSync: async () => {},
+      online: {
+        registerOnlineRetry(handler) {
+          handler();
+          return cleanup;
+        },
+      },
+    });
+
+    await controller.reconcile();
+    await Promise.resolve();
+
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    await controller.forceLogout();
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("retries a transient refresh on a timer even without an online event", async () => {
+    vi.useFakeTimers();
+    try {
+      const transport = makeTransport({
+        refreshResults: [
+          { kind: "transient", reason: "status 503" },
+          { kind: "ok", session: makeSession("u1") },
+        ],
+      });
+      const refreshSpy = vi.spyOn(transport, "refreshSession");
+      const controller = createAuthController({
+        transport,
+        authStateRepo: makeRepo(),
+        performInitialSync: async () => {},
+      });
+
+      await controller.reconcile();
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(refreshSpy).toHaveBeenCalledTimes(2);
+      expect(controller.getState().syncReady).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("login triggers onUserSwitch when previous userId differs", async () => {
     const transport = makeTransport({
       loginSession: makeSession("new-user"),
@@ -305,6 +403,35 @@ describe("createAuthController", () => {
     await controller.login("id", "pw");
 
     expect(onUserSwitch).not.toHaveBeenCalled();
+  });
+
+  it("login 開始時に session version を更新し、logout 後の遅延 login 応答を破棄する", async () => {
+    let resolveLogin!: (session: AuthSession) => void;
+    const loginSession = new Promise<AuthSession>((resolve) => {
+      resolveLogin = resolve;
+    });
+    const transport = makeTransport();
+    transport.login = () => loginSession;
+    const controller = createAuthController({
+      transport,
+      authStateRepo: makeRepo(),
+      performInitialSync: async () => {},
+    });
+
+    const initialVersion = controller.getSessionVersion();
+    const pendingLogin = controller.login("id", "pw");
+    expect(controller.getSessionVersion()).toBe(initialVersion + 1);
+
+    await controller.forceLogout();
+    resolveLogin(makeSession("late-user"));
+    await pendingLogin;
+
+    expect(controller.getState()).toMatchObject({
+      isLoggedIn: false,
+      userId: null,
+      syncReady: false,
+    });
+    expect(transport.accessToken).toBeNull();
   });
 
   it("register sets tutorial_status=pending", async () => {
@@ -495,6 +622,66 @@ describe("createAuthController", () => {
     });
     // logout 後の accessToken も null のまま (stale reconcile が書き戻していない)
     expect(transport.accessToken).toBe(null);
+  });
+
+  it("遅延 logout 完了後も、後から成立した login session をリセットしない", async () => {
+    let resolveLogout!: (result: { ok: boolean }) => void;
+    const logoutResult = new Promise<{ ok: boolean }>((resolve) => {
+      resolveLogout = resolve;
+    });
+    const transport = makeTransport({
+      loginSession: makeSession("new-user"),
+      refreshResults: [{ kind: "ok", session: makeSession("old-user") }],
+    });
+    transport.logout = () => logoutResult;
+    const controller = createAuthController({
+      transport,
+      authStateRepo: makeRepo(),
+      performInitialSync: async () => {},
+    });
+    await controller.reconcile();
+
+    const pendingLogout = controller.logout();
+    await controller.login("new", "pw");
+    resolveLogout({ ok: true });
+    await pendingLogout;
+
+    expect(controller.getState()).toMatchObject({
+      isLoggedIn: true,
+      userId: "new-user",
+      syncReady: true,
+    });
+    expect(transport.accessToken).toBe("tok-new-user");
+  });
+
+  it("遅延 forceLogout cleanup 後も、後から成立した login session をリセットしない", async () => {
+    let resolveCleanup!: () => void;
+    const cleanup = new Promise<void>((resolve) => {
+      resolveCleanup = resolve;
+    });
+    const transport = makeTransport({
+      loginSession: makeSession("new-user"),
+      refreshResults: [{ kind: "ok", session: makeSession("old-user") }],
+    });
+    transport.clearPersistedSession = () => cleanup;
+    const controller = createAuthController({
+      transport,
+      authStateRepo: makeRepo(),
+      performInitialSync: async () => {},
+    });
+    await controller.reconcile();
+
+    const pendingForceLogout = controller.forceLogout();
+    await controller.login("new", "pw");
+    resolveCleanup();
+    await pendingForceLogout;
+
+    expect(controller.getState()).toMatchObject({
+      isLoggedIn: true,
+      userId: "new-user",
+      syncReady: true,
+    });
+    expect(transport.accessToken).toBe("tok-new-user");
   });
 
   it("subscribe / unsubscribe correctly notifies listeners", async () => {

--- a/packages/auth-client/createAuthController.ts
+++ b/packages/auth-client/createAuthController.ts
@@ -1,3 +1,4 @@
+import { newAuthRetryScheduler } from "./authRetryScheduler";
 import type {
   AuthController,
   AuthControllerOptions,
@@ -27,10 +28,8 @@ export function createAuthController(
 
   let state: AuthControllerState = initialState;
   const listeners = new Set<() => void>();
-  // セッション世代カウンタ。login / logout / handleAuthExpired / 各 reconcile で
-  // increment し、走行中の非同期処理が古い世代の結果で state を上書きしないよう守る
   let generation = 0;
-  let onlineCleanup: (() => void) | null = null;
+  const retryScheduler = newAuthRetryScheduler(online);
 
   const emit = () => {
     for (const l of listeners) l();
@@ -38,13 +37,6 @@ export function createAuthController(
   const setState = (patch: Partial<AuthControllerState>) => {
     state = { ...state, ...patch };
     emit();
-  };
-
-  const clearOnlineRetry = () => {
-    if (onlineCleanup) {
-      onlineCleanup();
-      onlineCleanup = null;
-    }
   };
 
   const applySession = async (
@@ -67,23 +59,34 @@ export function createAuthController(
     await onUserSynced?.(session.user);
     if (gen !== generation) return false;
     setState({ userId: session.user.id, isLoggedIn: true });
-    await performInitialSync(session.user.id);
+    try {
+      await performInitialSync(session.user.id);
+    } catch {
+      // 認証自体は成立しているため logged-in state は保持する。ただし保護用の
+      // initial pull が成功するまでは syncReady を上げず、一時障害として再試行する。
+      registerOnlineRetry(gen);
+      return false;
+    }
     if (gen !== generation) return false;
+    retryScheduler.reset();
     setState({ syncReady: true });
     return true;
   };
 
-  const resetAuthState = async () => {
+  const resetAuthState = async (gen: number): Promise<boolean> => {
     transport.setAccessToken(null);
     await authStateRepo.clearLastLoginAt();
+    if (gen !== generation) return false;
     await onAuthStateReset?.();
+    if (gen !== generation) return false;
     setState({ isLoggedIn: false, syncReady: false, userId: null });
+    return true;
   };
 
-  const finalizeLogin = async (session: AuthSession): Promise<void> => {
+  const beginSessionChange = () => {
     const gen = ++generation;
-    clearOnlineRetry();
-    await applySession(session, gen);
+    retryScheduler.reset();
+    return gen;
   };
 
   const hydrate = async () => {
@@ -100,6 +103,7 @@ export function createAuthController(
 
   const reconcile = async (): Promise<boolean> => {
     const gen = ++generation;
+    retryScheduler.clear();
     let result: Awaited<ReturnType<typeof transport.refreshSession>>;
     try {
       result = await transport.refreshSession();
@@ -111,7 +115,8 @@ export function createAuthController(
     if (gen !== generation) return false;
 
     if (result.kind === "expired") {
-      await resetAuthState();
+      retryScheduler.reset();
+      await resetAuthState(gen);
       return false;
     }
     if (result.kind === "transient") {
@@ -122,18 +127,16 @@ export function createAuthController(
   };
 
   const registerOnlineRetry = (gen: number) => {
-    if (!online || gen !== generation) return;
-    clearOnlineRetry();
-    onlineCleanup = online.registerOnlineRetry(() => {
-      // adapter 側の登録解除 (NetInfo.removeEventListener / window.removeEventListener)
-      // を明示的に呼ばないと、reconcile が成功してもリスナーが生き続けてしまう
-      clearOnlineRetry();
+    if (gen !== generation) return;
+    retryScheduler.schedule(() => {
+      if (gen !== generation) return;
       void reconcile();
     });
   };
 
   return {
     getState: () => state,
+    getSessionVersion: () => generation,
     subscribe: (listener) => {
       listeners.add(listener);
       return () => {
@@ -143,47 +146,54 @@ export function createAuthController(
     hydrate,
     reconcile,
     login: async (loginId, password) => {
+      const gen = beginSessionChange();
       const session = await transport.login(loginId, password);
-      await finalizeLogin(session);
+      if (gen !== generation) return;
+      await applySession(session, gen);
     },
     register: async (loginId, password, consents) => {
+      const gen = beginSessionChange();
       const session = await transport.register(loginId, password, consents);
-      await finalizeLogin(session);
-      await authStateRepo.setTutorialStatus("pending");
+      if (gen !== generation) return;
+      await applySession(session, gen);
+      if (gen === generation) {
+        await authStateRepo.setTutorialStatus("pending");
+      }
     },
     googleLogin: async (credential, consents) => {
+      const gen = beginSessionChange();
       const session = await transport.googleLogin(credential, consents);
-      await finalizeLogin(session);
+      if (gen !== generation) return;
+      await applySession(session, gen);
     },
     appleLogin: async (credential, consents) => {
+      const gen = beginSessionChange();
       const session = await transport.appleLogin(credential, consents);
-      await finalizeLogin(session);
+      if (gen !== generation) return;
+      await applySession(session, gen);
     },
     applyExternalSession: async (session) => {
+      const gen = beginSessionChange();
       await transport.persistSession(session);
-      await finalizeLogin(session);
+      if (gen !== generation) return;
+      await applySession(session, gen);
     },
     logout: async () => {
-      generation++;
-      clearOnlineRetry();
-      // transport.logout は authMiddleware が Bearer 必須なので、有効な
-      // access token (tokenHolder) が残っている状態で先に呼ぶ。
-      // 失敗時は local state を保持して再試行可能にする — Web の httpOnly
-      // cookie が残ったままだと次回起動で自動再ログインしてしまう。
+      const gen = ++generation;
+      retryScheduler.reset();
+      // backend logout は Bearer 必須なので、local reset より先に呼ぶ。
       const result = await transport.logout().catch(() => ({ ok: false }));
-      if (result.ok) {
-        await resetAuthState();
+      if (result.ok && gen === generation) {
+        await resetAuthState(gen);
       }
       return result;
     },
     forceLogout: async () => {
-      generation++;
-      clearOnlineRetry();
-      // delete account 後など server cleanup が通らないケースで呼ばれるので、
-      // 永続層 (Mobile の SecureStore など) も明示的にクリアする。backend は
-      // 既に revoke 済みなので残しても再利用はできないが、識別子残存を避ける
+      const gen = ++generation;
+      retryScheduler.reset();
+      // server cleanup を介さない経路でも永続 credential を削除する。
       await transport.clearPersistedSession().catch(() => {});
-      await resetAuthState();
+      if (gen === generation) await resetAuthState(gen);
     },
   };
 }

--- a/packages/auth-client/index.ts
+++ b/packages/auth-client/index.ts
@@ -1,3 +1,5 @@
+export { newAuthOperationCoordinator } from "./authOperationCoordinator";
+export { classifyRefreshFailure } from "./classifyRefreshFailure";
 export { createAuthController } from "./createAuthController";
 export type {
   AccessTokenSource,
@@ -8,7 +10,10 @@ export { createAuthenticatedFetch } from "./http/createAuthenticatedFetch";
 export { useAuthBootstrap, useAuthController } from "./react/useAuthController";
 export type { LogoutActionResult } from "./react/useLogoutAction";
 export { useLogoutAction } from "./react/useLogoutAction";
-export { createRefreshAccessTokenCallback } from "./refreshAccessTokenWiring";
+export {
+  type RefreshAccessTokenCallbackOptions,
+  createRefreshAccessTokenCallback,
+} from "./refreshAccessTokenWiring";
 export type {
   AuthController,
   AuthControllerOptions,

--- a/packages/auth-client/refreshAccessTokenWiring.test.ts
+++ b/packages/auth-client/refreshAccessTokenWiring.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createRefreshAccessTokenCallback } from "./refreshAccessTokenWiring";
 import type { AuthSession, AuthTransport } from "./types";
@@ -65,6 +65,24 @@ describe("createRefreshAccessTokenCallback", () => {
     expect(transport.setAccessTokenCalls).toEqual([]);
   });
 
+  it("refresh kind: expired 時: onExpired の完了を待ってから null を返す", async () => {
+    const transport = makeTransport({
+      refresh: async () => ({ kind: "expired" }),
+    });
+    const calls: string[] = [];
+    const onExpired = vi.fn(async () => {
+      await Promise.resolve();
+      calls.push("expired");
+    });
+    const callback = createRefreshAccessTokenCallback(transport, { onExpired });
+
+    const result = await callback();
+
+    expect(result).toBeNull();
+    expect(onExpired).toHaveBeenCalledOnce();
+    expect(calls).toEqual(["expired"]);
+  });
+
   it("refresh kind: transient 時: setAccessToken を呼ばず null を返す", async () => {
     const transport = makeTransport({
       refresh: async () => ({ kind: "transient", reason: "status 500" }),
@@ -72,6 +90,65 @@ describe("createRefreshAccessTokenCallback", () => {
     const callback = createRefreshAccessTokenCallback(transport);
 
     expect(await callback()).toBeNull();
+    expect(transport.setAccessTokenCalls).toEqual([]);
+  });
+
+  it("refresh kind: transient 時: onExpired を呼ばない", async () => {
+    const transport = makeTransport({
+      refresh: async () => ({ kind: "transient", reason: "status 429" }),
+    });
+    const onExpired = vi.fn();
+    const callback = createRefreshAccessTokenCallback(transport, { onExpired });
+
+    expect(await callback()).toBeNull();
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it("refresh 待機中に session version が変わったら古い expired を通知しない", async () => {
+    let resolveRefresh!: (
+      result: Awaited<ReturnType<AuthTransport["refreshSession"]>>,
+    ) => void;
+    const refresh = new Promise<
+      Awaited<ReturnType<AuthTransport["refreshSession"]>>
+    >((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const transport = makeTransport({ refresh: () => refresh });
+    const onExpired = vi.fn();
+    let sessionVersion = 1;
+    const callback = createRefreshAccessTokenCallback(transport, {
+      getSessionVersion: () => sessionVersion,
+      onExpired,
+    });
+
+    const pending = callback();
+    sessionVersion++;
+    resolveRefresh({ kind: "expired" });
+
+    await expect(pending).resolves.toBeNull();
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+
+  it("refresh 待機中に session version が変わったら古い token を反映しない", async () => {
+    let resolveRefresh!: (
+      result: Awaited<ReturnType<AuthTransport["refreshSession"]>>,
+    ) => void;
+    const refresh = new Promise<
+      Awaited<ReturnType<AuthTransport["refreshSession"]>>
+    >((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const transport = makeTransport({ refresh: () => refresh });
+    let sessionVersion = 1;
+    const callback = createRefreshAccessTokenCallback(transport, {
+      getSessionVersion: () => sessionVersion,
+    });
+
+    const pending = callback();
+    sessionVersion++;
+    resolveRefresh({ kind: "ok", session: makeSession("stale-jwt") });
+
+    await expect(pending).resolves.toBeNull();
     expect(transport.setAccessTokenCalls).toEqual([]);
   });
 

--- a/packages/auth-client/refreshAccessTokenWiring.ts
+++ b/packages/auth-client/refreshAccessTokenWiring.ts
@@ -1,15 +1,32 @@
 import type { AuthTransport } from "./types";
 
+export type RefreshAccessTokenCallbackOptions = {
+  getSessionVersion?: () => number;
+  onExpired?: () => void | Promise<void>;
+};
+
 // createAuthenticatedFetch の refreshAccessToken に渡す callback を生成する。
 // 401 retry の直後の本リクエストだけでなく、後続リクエストも新 token で送るには
 // tokenHolder (= transport.setAccessToken の対象) も更新する必要がある。
 // Web/Mobile の authController.ts (composition root) で共通に使う。
 export function createRefreshAccessTokenCallback(
   transport: AuthTransport,
+  options: RefreshAccessTokenCallbackOptions = {},
 ): () => Promise<string | null> {
   return async () => {
+    const sessionVersion = options.getSessionVersion?.();
     const result = await transport.refreshSession();
-    if (result.kind !== "ok") return null;
+    if (
+      sessionVersion !== undefined &&
+      sessionVersion !== options.getSessionVersion?.()
+    ) {
+      return null;
+    }
+    if (result.kind === "expired") {
+      await options.onExpired?.();
+      return null;
+    }
+    if (result.kind === "transient") return null;
     transport.setAccessToken(result.session.token);
     return result.session.token;
   };

--- a/packages/auth-client/types.ts
+++ b/packages/auth-client/types.ts
@@ -51,7 +51,8 @@ export type AuthStateRepository = {
 };
 
 export type OnlineRetryAdapter = {
-  // online イベント等の "ネットワーク復帰" を待つ。コールバック呼び出し後の cleanup を返す
+  // online イベント等の "ネットワーク復帰" を待つ。現在状態の初回 snapshot ではなく、
+  // offline -> online の遷移時に handler を呼び、cleanup を返す。
   registerOnlineRetry(handler: () => void): () => void;
 };
 
@@ -78,6 +79,7 @@ export type AuthControllerOptions = {
 
 export type AuthController = {
   getState(): AuthControllerState;
+  getSessionVersion(): number;
   subscribe(listener: () => void): () => void;
   // local の last_login_at で UI を即出す
   hydrate(): Promise<void>;


### PR DESCRIPTION
## 概要

認証レビューで確認した 1〜6 の問題について、先に失敗する回帰テストを追加し、Web/Mobile 共通の認証状態管理を修正しました。

## 原因と修正

- runtime refresh の確定的な期限切れ時だけ local auth state をリセット
- 初期同期失敗を logged-in / syncReady=false のまま指数バックオフと offline→online で再試行
- 429 などを expired ではなく transient として分類
- session generation で古い refresh/login/logout 完了結果を破棄
- Web/Mobile の login・refresh・logout・credential 永続化を FIFO 直列化し、同時 refresh を single-flight 化
- Web logout の 401 時に refresh の expired/transient/ok を分け、ok 時のみ新 token で再送
- Mobile logout 時の refresh token rotation と SecureStore cleanup を同じ直列化境界で処理

## Red → Green

修正前に追加テストを実行し、対象 6 項目に対応する 8 テストが失敗することを確認しました。修正後は認証関連 11 files / 105 tests がすべて成功しています。

## 検証

- pnpm run test-once: 196 files / 2,238 tests passed
- pnpm run ci-check: passed
  - backend/date/widget-schema guards
  - full Vitest suite
  - Biome lint
  - root/admin/mobile TypeScript checks
- git diff --check: passed
- Codex reviewer 2 系統で 3 ラウンド再レビューし、双方 LGTM

UI/DOM、API、DB schema、依存関係の変更はありません。Mobile は JS/TS-only のため OTA 配信可能で、native rebuild は不要です。