### PR TITLE
fix(ci): post-deploy smokeを再試行する

### DIFF
--- a/scripts/post-deploy-smoke.js
+++ b/scripts/post-deploy-smoke.js
@@ -1,13 +1,41 @@
 #!/usr/bin/env node
 
-export async function smokeEndpoint(name, url, fetchImpl = fetch) {
-  const response = await fetchImpl(url, {
-    headers: { "User-Agent": "actiko-release-smoke/1" },
-    redirect: "follow",
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!response.ok) throw new Error(`${name} smoke failed with HTTP ${response.status}`);
-  return { name, status: response.status };
+const sleep = (delayMs) =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
+
+export async function smokeEndpoint(
+  name,
+  url,
+  fetchImpl = fetch,
+  {
+    maxAttempts = 5,
+    retryDelayMs = 3_000,
+    sleepImpl = sleep,
+  } = {},
+) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(url, {
+        headers: { "User-Agent": "actiko-release-smoke/1" },
+        redirect: "follow",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (response.ok) return { name, status: response.status };
+      lastError = new Error(
+        `${name} smoke failed with HTTP ${response.status}`,
+      );
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt < maxAttempts) {
+      await sleepImpl(retryDelayMs * attempt);
+    }
+  }
+
+  throw lastError;
 }
 
 function parseEndpoints(args) {

--- a/scripts/post-deploy-smoke.test.ts
+++ b/scripts/post-deploy-smoke.test.ts
@@ -19,8 +19,35 @@ describe("post-deploy smoke", () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(new Response("secret body", { status: 503 }));
+    const sleepImpl = vi.fn().mockResolvedValue(undefined);
     await expect(
-      smokeEndpoint("web", "https://web.example.test", fetchImpl),
+      smokeEndpoint("web", "https://web.example.test", fetchImpl, {
+        maxAttempts: 3,
+        retryDelayMs: 1,
+        sleepImpl,
+      }),
     ).rejects.toThrow("web smoke failed with HTTP 503");
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(sleepImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries transient deployment responses before succeeding", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const sleepImpl = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      smokeEndpoint("api", "https://api.example.test", fetchImpl, {
+        maxAttempts: 3,
+        retryDelayMs: 1,
+        sleepImpl,
+      }),
+    ).resolves.toEqual({ name: "api", status: 200 });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(sleepImpl).toHaveBeenNthCalledWith(1, 1);
+    expect(sleepImpl).toHaveBeenNthCalledWith(2, 2);
   });
 });


### PR DESCRIPTION
## 概要

Cloudflare 配備直後の一時的な 403/5xx で post-deploy smoke が誤検知しないよう、最大5回の線形 backoff retryを追加します。永続的な失敗は従来どおり最終HTTP statusで失敗します。

## 検証

- 先に403→503→200の回帰テストを追加し、修正前に失敗を確認
- `pnpm vitest run scripts/post-deploy-smoke.test.ts`
- `pnpm run ci-check`（242 files、2466 tests、lint、typecheck）