### PR TITLE
fix(ci): release E2E用Chromiumを準備する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,10 @@ jobs:
           CI: true
           NODE_ENV: test
 
+      - name: Install Chromium for Web E2E release gate
+        if: github.ref_name == 'release'
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Web E2E release gate
         if: github.ref_name == 'release'
         run: pnpm run test-e2e

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -26,6 +26,16 @@ describe("release workflow guards", () => {
     expect(workflow).toContain("Post-deploy smoke (production)");
   });
 
+  it("installs the lockfile-matched Chromium before the release E2E gate", () => {
+    const installBrowser = workflow.indexOf(
+      "pnpm exec playwright install --with-deps chromium",
+    );
+    const runE2E = workflow.indexOf("pnpm run test-e2e");
+
+    expect(installBrowser).toBeGreaterThan(-1);
+    expect(installBrowser).toBeLessThan(runE2E);
+  });
+
   it("requires an approved SHA and rejects native changes for OTA", () => {
     expect(workflow).toContain("mobile_release_sha:");
     expect(workflow).toContain('GITHUB_REF" != "refs/heads/release');


### PR DESCRIPTION
## 概要

release workflow の Web E2E gate 前に、lockfile上のPlaywrightと一致するChromiumおよび実行依存をインストールします。

## 原因

#235でrelease E2E gateを追加した一方、PR workflowにあるbrowser install手順がdeploy workflowにはありませんでした。

## 検証

- 先にbrowser install順序の回帰テストを追加し、修正前に失敗を確認
- `pnpm vitest run scripts/release-workflow.test.ts`
- `pnpm run ci-check`（242 files、2467 tests、lint、typecheck）