### PR TITLE
release: E2E browser setup hotfix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,10 @@ jobs:
           CI: true
           NODE_ENV: test
 
+      - name: Install Chromium for Web E2E release gate
+        if: github.ref_name == 'release'
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Web E2E release gate
         if: github.ref_name == 'release'
         run: pnpm run test-e2e

--- a/scripts/release-workflow.test.ts
+++ b/scripts/release-workflow.test.ts
@@ -26,6 +26,16 @@ describe("release workflow guards", () => {
     expect(workflow).toContain("Post-deploy smoke (production)");
   });
 
+  it("installs the lockfile-matched Chromium before the release E2E gate", () => {
+    const installBrowser = workflow.indexOf(
+      "pnpm exec playwright install --with-deps chromium",
+    );
+    const runE2E = workflow.indexOf("pnpm run test-e2e");
+
+    expect(installBrowser).toBeGreaterThan(-1);
+    expect(installBrowser).toBeLessThan(runE2E);
+  });
+
   it("requires an approved SHA and rejects native changes for OTA", () => {
     expect(workflow).toContain("mobile_release_sha:");
     expect(workflow).toContain('GITHUB_REF" != "refs/heads/release');


### PR DESCRIPTION
## 概要

失敗したproduction release workflowのE2E環境を修復します。Playwright ChromiumをE2E gate前にインストールし、テストで実行順序を固定しました。

## 状態

- 前回production runはE2E gateで停止
- DB migration / Backend / Web / Admin / Tailのproduction配備は未実行
- PR #239 CIはunit / E2E / lint / typecheckすべてgreen
- Mobile build / OTAは対象外