### PR TITLE
fix: 本番の初期描画クラッシュを解消

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -48,19 +48,7 @@ export default defineConfig({
     outDir: "../../dist-frontend-v2",
     emptyOutDir: true,
     sourcemap: false,
-    rolldownOptions: {
-      output: {
-        codeSplitting: {
-          groups: [
-            {
-              name: "vendor",
-              test: /node_modules[\\/]/,
-              maxSize: 350_000,
-              priority: 10,
-            },
-          ],
-        },
-      },
-    },
+    // Keep Vite's default splitting. Forced vendor groups can create Rolldown
+    // evaluation cycles that crash before React mounts (rolldown#10228).
   },
 });


### PR DESCRIPTION
## 原因

PR #235 で追加された Rolldown の強制 vendor 分割が、未解決の cross-chunk 評価順バグを発火させていました。生成された React/Dexie vendor chunk が初期化前の関数を呼び、画面描画前に TypeError: n is not a function で停止していました。

- upstream: https://github.com/rolldown/rolldown/issues/10228
- follow-up: https://github.com/rolldown/rolldown/issues/10673

## 修正

独自の 350KB vendor 強制分割を削除し、Vite 標準の code splitting に戻します。route 単位の dynamic import は維持されます。

## 検証

- 修正前 production preview: 空画面、vendor-mXZcfZtw.js:1:9810 で TypeError
- 修正後 production preview: ログイン画面まで描画、bundle error なし
- pnpm build-client: 成功
- pnpm ci-check: 241 files / 2470 tests pass、lint・typecheck 成功