### PR TITLE
release: 本番初期描画クラッシュ修正

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -48,19 +48,7 @@ export default defineConfig({
     outDir: "../../dist-frontend-v2",
     emptyOutDir: true,
     sourcemap: false,
-    rolldownOptions: {
-      output: {
-        codeSplitting: {
-          groups: [
-            {
-              name: "vendor",
-              test: /node_modules[\\/]/,
-              maxSize: 350_000,
-              priority: 10,
-            },
-          ],
-        },
-      },
-    },
+    // Keep Vite's default splitting. Forced vendor groups can create Rolldown
+    // evaluation cycles that crash before React mounts (rolldown#10228).
   },
 });


### PR DESCRIPTION
## リリース内容

PR #243 の修正を production へ反映します。

- PR #235 で追加された強制 vendor chunk 分割を削除
- Vite 標準の code splitting へ戻す
- Rolldown cross-chunk 評価順による初期描画クラッシュを解消

## 検証

- PR #243 CI: 全成功
- staging deploy run 32565106745: migration / Workers / frontend / admin / tail / smoke 全成功
- staging 実ブラウザ: ログイン画面まで描画、問題の TypeError なし
- mobile release: 対象外